### PR TITLE
Implement save item corruption prevention

### DIFF
--- a/LethalLevelLoader/Components/LLLSaveFile.cs
+++ b/LethalLevelLoader/Components/LLLSaveFile.cs
@@ -9,32 +9,45 @@ namespace LethalLevelLoader
     {
         public string CurrentLevelName { get; internal set; } = string.Empty;
 
-        public Dictionary<string, string> customItemDictionary = new Dictionary<string, string>();
-
-        public List<string> allItemsList = new List<string>();
-
-        public List<AllItemsListItemData> itemSaveDataList = new List<AllItemsListItemData>();
+        public int parityStepsTaken;
         public Dictionary<int, AllItemsListItemData> itemSaveData = new Dictionary<int, AllItemsListItemData>();
 
-        public LLLSaveFile(string name)
+        public LLLSaveFile()
         {
-            OptionalPrefixSuffix = name;
+            //OptionalPrefixSuffix = name;
+        }
+
+        public void Reset()
+        {
+            CurrentLevelName = string.Empty;
+            parityStepsTaken = 0;
+            itemSaveData = new Dictionary<int, AllItemsListItemData>();
         }
     }
 
     public struct AllItemsListItemData
     {
+        public string itemObjectName;
         public string itemName;
-        public string itemDisplayName;
         public string modName;
+        public string modAuthor;
         public int allItemsListIndex;
+        public int modItemsListIndex;
+        public int itemNameDuplicateIndex;
+        public bool isScrap;
+        public bool saveItemVariable;
 
-        public AllItemsListItemData(string newItemName, string newItemDisplayName, string newModName, int newAllItemsListIndex)
+        public AllItemsListItemData(string newItemObjectName, string newItemName, string newModName, string newModAuthor, int newAllItemsListIndex, int newModItemsListIndex, int newItemNameDuplicateIndex, bool newIsScrap, bool newSaveItemVariable)
         {
+            itemObjectName = newItemObjectName;
             itemName = newItemName;
-            itemDisplayName = newItemDisplayName;
             modName = newModName;
+            modAuthor = newModAuthor;
             allItemsListIndex = newAllItemsListIndex;
+            modItemsListIndex = newModItemsListIndex;
+            itemNameDuplicateIndex = newItemNameDuplicateIndex;
+            isScrap = newIsScrap;
+            saveItemVariable = newSaveItemVariable;
         }
     }
 }

--- a/LethalLevelLoader/General/Patches.cs
+++ b/LethalLevelLoader/General/Patches.cs
@@ -7,6 +7,7 @@ using LethalLevelLoader.Tools;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Emit;
 using System.Text;
 using TMPro;
@@ -133,6 +134,18 @@ namespace LethalLevelLoader
         }
 
         [HarmonyPriority(harmonyPriority)]
+        [HarmonyPatch(typeof(GameNetworkManager), "SaveGameValues")]
+        [HarmonyPostfix]
+        internal static void GameNetworkManagerSaveGameValues_Postfix(GameNetworkManager __instance)
+        {
+            // Vanilla checks
+            if (!__instance.isHostingGame || !StartOfRound.Instance.inShipPhase || StartOfRound.Instance.isChallengeFile)
+                return;
+
+            SaveManager.SaveGameValues();
+        }
+
+        [HarmonyPriority(harmonyPriority)]
         [HarmonyPatch(typeof(StartOfRound), "Awake")]
         [HarmonyPrefix]
         internal static void StartOfRoundAwake_Prefix(StartOfRound __instance)
@@ -151,12 +164,10 @@ namespace LethalLevelLoader
             SceneManager.sceneLoaded += EventPatches.OnSceneLoaded;
 
             //Removing the broken cardboard box item please understand 
-
             //Scrape Vanilla For Content References
             if (Plugin.IsSetupComplete == false)
             {
                 StartOfRound.allItemsList.itemsList.RemoveAt(2);
-                SaveManager.defaultCachedItemsList = new List<Item>(StartOfRound.allItemsList.itemsList);
 
                 DebugStopwatch.StartStopWatch("Scrape Vanilla Content");
                 ContentExtractor.TryScrapeVanillaItems(StartOfRound);
@@ -308,7 +319,6 @@ namespace LethalLevelLoader
             if (LethalLevelLoaderNetworkManager.networkManager.IsServer)
             {
                 SaveManager.InitializeSave();
-                SaveManager.RefreshSaveItemInfo();
             }
 
             DebugStopwatch.StopStopWatch("Initalize Save");
@@ -385,7 +395,8 @@ namespace LethalLevelLoader
             if (RoundManager.currentLevel != null && SaveManager.currentSaveFile.CurrentLevelName != RoundManager.currentLevel.PlanetName)
             {
                 DebugHelper.Log("Saving Current SelectableLevel: " + RoundManager.currentLevel.PlanetName, DebugType.User);
-                SaveManager.SaveCurrentSelectableLevel(RoundManager.currentLevel);
+                SaveManager.currentSaveFile.CurrentLevelName = RoundManager.currentLevel.PlanetName;
+                //SaveManager.SaveCurrentSelectableLevel(RoundManager.currentLevel);
                 //LevelLoader.RefreshShipAnimatorClips(LevelManager.CurrentExtendedLevel);
             }
             
@@ -394,11 +405,9 @@ namespace LethalLevelLoader
         [HarmonyPriority(harmonyPriority)]
         [HarmonyPatch(typeof(StartOfRound), "LoadShipGrabbableItems")]
         [HarmonyPrefix]
-        internal static bool StartOfRoundLoadShipGrabbableItems_Prefix()
+        internal static void StartOfRoundLoadShipGrabbableItems_Prefix()
         {
-            //SaveManager.LoadShipGrabbableItems(); 
-            //return (false);
-            return (true);
+            SaveManager.LoadShipGrabbableItems();
         }
 
 

--- a/LethalLevelLoader/Patches/SaveManager.cs
+++ b/LethalLevelLoader/Patches/SaveManager.cs
@@ -1,28 +1,26 @@
-﻿using System;
+﻿using LethalLib.Modules;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Unity.Netcode;
 using UnityEngine;
-using static LethalLevelLoader.SaveManager;
 
 namespace LethalLevelLoader
 {
     internal static class SaveManager
     {
         public static LLLSaveFile currentSaveFile;
-        public static List<Item> defaultCachedItemsList = new List<Item>(); 
+        public static bool parityCheck;
 
         internal static void InitializeSave()
         {
             if (LethalLevelLoaderNetworkManager.networkManager.IsServer == false)
                 return;
 
-            if (GameNetworkManager.Instance.currentSaveFileName.Contains("LC"))
-                currentSaveFile = new LLLSaveFile(GameNetworkManager.Instance.currentSaveFileName.Replace("LC", "LLL"));
-            else
-                currentSaveFile = new LLLSaveFile("LLLSaveFile");
+            currentSaveFile = new LLLSaveFile();
             currentSaveFile.Load();
+
             if (currentSaveFile.CurrentLevelName != null)
                 DebugHelper.Log("Initialized LLL Save File, Current Level Was: " + currentSaveFile.CurrentLevelName + ", Current Vanilla Save Is: " + GameNetworkManager.Instance.currentSaveFileName, DebugType.User);
             else
@@ -30,211 +28,51 @@ namespace LethalLevelLoader
 
             if (ES3.KeyExists("CurrentPlanetID", GameNetworkManager.Instance.currentSaveFileName))
                 DebugHelper.Log("Vanilla CurrentSaveFileName Has Saved Current Planet ID: " + ES3.Load<int>("CurrentPlanetID", GameNetworkManager.Instance.currentSaveFileName), DebugType.Developer);
+
+            // Compare saved "Steps Taken" statistic, to try to check whether the Vanilla and LethalLevelLoader saves are the same
+            int originalStepsTaken = ES3.Load<int>("Stats_StepsTaken", GameNetworkManager.Instance.currentSaveFileName, 0);
+
+            if (originalStepsTaken == currentSaveFile.parityStepsTaken)
+                parityCheck = true;
             else
             {
-                currentSaveFile.customItemDictionary = new Dictionary<string, string>();
-                currentSaveFile.allItemsList = new List<string>();
-                currentSaveFile.itemSaveDataList = new List<AllItemsListItemData>();
-                currentSaveFile.itemSaveData = new Dictionary<int, AllItemsListItemData>();
-                currentSaveFile.CurrentLevelName = string.Empty;
+                DebugHelper.Log("Vanilla Save File Mismatch, LLL Steps Taken: " + currentSaveFile.parityStepsTaken + ", Vanilla Steps Taken: " + originalStepsTaken, DebugType.Developer);
+
+                currentSaveFile.Reset();
+                currentSaveFile.parityStepsTaken = originalStepsTaken;
+
+                parityCheck = false;
             }
-
-            if (currentSaveFile.customItemDictionary == null)
-                currentSaveFile.customItemDictionary = new Dictionary<string, string>();
-            if (currentSaveFile.allItemsList == null)
-                currentSaveFile.allItemsList = new List<string>();
-            if (currentSaveFile.itemSaveDataList == null)
-                currentSaveFile.itemSaveDataList = new List<AllItemsListItemData>();
-            if (currentSaveFile.itemSaveData == null)
-                currentSaveFile.itemSaveData = new Dictionary<int, AllItemsListItemData>();
-            if (currentSaveFile.CurrentLevelName == null)
-                currentSaveFile.CurrentLevelName = string.Empty;
-
-            /*foreach (string item in currentSaveFile.allItemsList)
-                DebugHelper.Log("Saved AllItemsList: " + item);
-
-            foreach (KeyValuePair<string, string> extendedItemSaveInfo in currentSaveFile.customItemDictionary)
-                DebugHelper.Log("Save Item Info: " + extendedItemSaveInfo.Key + " from " + extendedItemSaveInfo.Value);*/
-
-            //foreach (AllItemsListItemData itemSaveData in currentSaveFile.itemSaveDataList)
-                //DebugHelper.Log("Item Save Data: " + itemSaveData.itemName + ", " + itemSaveData.itemDisplayName + ", " + itemSaveData.modName + ", " + itemSaveData.allItemsListIndex, DebugType.Developer);
-
-
-            //ValidateSaveData();
         }
 
-        internal static ProcessedData ValidateSaveData()
+        internal static void SaveGameValues()
         {
-            List<int> savedAllItemsListIndices = null;
-            if (ES3.KeyExists("shipGrabbableItemIDs", GameNetworkManager.Instance.currentSaveFileName))
-                savedAllItemsListIndices = ES3.Load<int[]>("shipGrabbableItemIDs", GameNetworkManager.Instance.currentSaveFileName).ToList();
+            currentSaveFile.itemSaveData = GetAllItemsListItemDataDict();
+            currentSaveFile.parityStepsTaken = Patches.StartOfRound.gameStats.allStepsTaken;
 
-            List<AllItemsListItemData> savedItems = new List<AllItemsListItemData>();
-            List<AllItemsListItemData> liveItems = GetItemSaveData();
-
-            List<int> validIndicies = new List<int>();
-            Dictionary<int,int> recoveredIndicies = new Dictionary<int,int>();
-            List<int> invalidIndicies = new List<int>();
-
-            if (savedAllItemsListIndices != null)
-                foreach (int itemIndex in savedAllItemsListIndices)
-                    savedItems.Add(currentSaveFile.itemSaveData[itemIndex]);
-
-            foreach (AllItemsListItemData savedItem in savedItems)
-            {
-                if (savedItem.allItemsListIndex < liveItems.Count && savedItem.allItemsListIndex > -1 && liveItems[savedItem.allItemsListIndex].itemName == savedItem.itemName)
-                    validIndicies.Add(savedItem.allItemsListIndex);
-                else
-                {
-                    int recoveredItemIndex = -1;
-                    foreach (AllItemsListItemData liveItem in liveItems)
-                    {
-                        int compareCount = 0;
-                        if (savedItem.itemName == liveItem.itemName)
-                            compareCount++;
-                        if (savedItem.itemDisplayName == liveItem.itemDisplayName)
-                            compareCount++;
-                        if (savedItem.modName == liveItem.modName)
-                            compareCount++;
-                        if (compareCount >= 2)
-                            recoveredItemIndex = liveItems.IndexOf(liveItem);
-                    }
-                    if (recoveredItemIndex != -1)
-                        recoveredIndicies.Add(savedItem.allItemsListIndex, recoveredItemIndex);
-                    else
-                        invalidIndicies.Add(savedItem.allItemsListIndex);
-                }
-            }
-
-            return (new ProcessedData(validIndicies, recoveredIndicies, invalidIndicies));
-        }
-
-        internal static List<SavedShipItemData> ProcessSavedItemIndicies(ProcessedData processedData)
-        {
-            return (ProcessSavedItemIndicies(processedData.validIndicies, processedData.recoveredIndicies, processedData.invalidIndicies));
-        }
-
-        internal static List<SavedShipItemData> ProcessSavedItemIndicies(List<int> validIndices, Dictionary<int, int> recoveredIndicies, List<int> invalidIndicies)
-        {
-            AllItemsList patchedItemsList = Patches.StartOfRound.allItemsList;
-            List<SavedShipItemData> validatedSavedShipItemDataList = new List<SavedShipItemData>();
-            Dictionary<int, SavedShipItemData> constructedSavedShipItemDataDict = GetConstructedSavedShipItemData();
-
-            DebugHelper.Log("Processed Saved Items In: " + GameNetworkManager.Instance.currentSaveFileName, DebugType.User);
-            if (validIndices.Count > 0)
-            {
-                string validItemsLog = "Valid Saved Items: ";
-                foreach (int validIndex in validIndices)
-                    validItemsLog += patchedItemsList.itemsList[validIndex].itemName + ", ";
-                DebugHelper.Log(validItemsLog, DebugType.User);
-            }
-            if (recoveredIndicies.Count > 0)
-            {
-                string recoveredItemsLog = "Recovered Saved Items: ";
-                foreach (KeyValuePair<int, int> recoveredIndexPair in recoveredIndicies)
-                    recoveredItemsLog += patchedItemsList.itemsList[recoveredIndexPair.Value].itemName + ", ";
-                DebugHelper.LogWarning(recoveredItemsLog, DebugType.User);
-            }
-            if (invalidIndicies.Count > 0)
-            {
-                string invalidItemsLog = "Corrupted Saved Items: ";
-                foreach (int invalidIndex in invalidIndicies)
-                   invalidItemsLog += "Invalid ID: (" + invalidIndex + ")" + ", ";
-                DebugHelper.LogError(invalidItemsLog, DebugType.User);
-            }
-
-            foreach (SavedShipItemData savedShipItemData in constructedSavedShipItemDataDict.Values)
-                DebugHelper.Log("Constructed SavedShipItemData: " + savedShipItemData.itemAllItemsListIndex + " | " + savedShipItemData.itemPosition + " | " + savedShipItemData.itemScrapValue + " | " + savedShipItemData.itemAdditionalSavedData, DebugType.User);
-
-
-            foreach (int validIndex in validIndices)
-                validatedSavedShipItemDataList.Add(constructedSavedShipItemDataDict[validIndex]);
-
-            foreach (KeyValuePair<int, int> recoveredIndex in  recoveredIndicies)
-            {
-                constructedSavedShipItemDataDict[recoveredIndex.Key].itemAllItemsListIndex = recoveredIndex.Value;
-                validatedSavedShipItemDataList.Add(constructedSavedShipItemDataDict[recoveredIndex.Key]);
-            }
-
-            validatedSavedShipItemDataList = validatedSavedShipItemDataList.OrderBy(s => s.itemAllItemsListIndex).ToList();
-
-            foreach (SavedShipItemData savedShipItemData in validatedSavedShipItemDataList)
-                DebugHelper.Log("Validated SavedShipItemData: " + savedShipItemData.itemAllItemsListIndex + " | " + savedShipItemData.itemPosition + " | " + savedShipItemData.itemScrapValue + " | " + savedShipItemData.itemAdditionalSavedData, DebugType.User);
-
-            //OverrideCurrentSaveFileItemData(validatedSavedShipItemDataList);
-            return (validatedSavedShipItemDataList);
-        }
-
-        internal static void RefreshSaveItemInfo()
-        {
-            /*
-            currentSaveFile.customItemDictionary = new Dictionary<string, string>();
-
-            currentSaveFile.allItemsList = new List<string>();
-            foreach (Item item in Patches.StartOfRound.allItemsList.itemsList)
-                currentSaveFile.allItemsList.Add(item.name);
-
-            currentSaveFile.itemSaveDataList = GetItemSaveData();
-            currentSaveFile.itemSaveData.Clear();
-            foreach (AllItemsListItemData itemSaveData in GetItemSaveData())
-                if (!currentSaveFile.itemSaveData.ContainsKey(itemSaveData.allItemsListIndex))
-                    currentSaveFile.itemSaveData.Add(itemSaveData.allItemsListIndex, itemSaveData);
-
-            currentSaveFile.customItemDictionary.Clear();
-            foreach (ExtendedItem extendedItem in PatchedContent.ExtendedItems)
-                if (!currentSaveFile.customItemDictionary.ContainsKey(extendedItem.ModName + "_" + extendedItem.name))
-                    currentSaveFile.customItemDictionary.Add(extendedItem.ModName + "_" + extendedItem.name, extendedItem.ModName);
-
-
-            currentSaveFile.Save();*/
+            currentSaveFile.Save();
         }
 
         internal static void SaveCurrentSelectableLevel(SelectableLevel selectableLevel)
         {
+            /*
             if (LethalLevelLoaderNetworkManager.networkManager.IsServer == false)
                 return;
             currentSaveFile.CurrentLevelName = selectableLevel.name;
             currentSaveFile.Save();
-            
-        }
-
-        internal static List<AllItemsListItemData> GetItemSaveData()
-        {
-            List<AllItemsListItemData > items = new List<AllItemsListItemData>();
-            List<Item> itemsList = new List<Item>();
-            int counter = 0;
-            foreach (Item item in Patches.StartOfRound.allItemsList.itemsList)
-            {
-                foreach (ExtendedItem extendedItem in PatchedContent.ExtendedItems)
-                    if (extendedItem.Item == item && !itemsList.Contains(item))
-                    {
-                        itemsList.Add(item);
-                        items.Add(new AllItemsListItemData(item.name, item.itemName, extendedItem.ModName, counter));
-                        break;
-                    }
-                counter++;
-            }
-
-            return (items);
+            */
         }
 
         internal static void LoadShipGrabbableItems()
         {
-            List<int> shipGrabbableItemIDs = new List<int>();
-            List<Vector3> shipGrabbableItemPos = new List<Vector3>();
-            List<int> shipScrapValues = new List<int>();
-            List<int> shipItemSaveData = new List<int>();
+            if (!parityCheck)
+                return;
 
-            foreach (SavedShipItemData savedShipItemData in ProcessSavedItemIndicies(ValidateSaveData()))
-            {
-                shipGrabbableItemIDs.Add(savedShipItemData.itemAllItemsListIndex);
-                if (savedShipItemData.itemPosition != new Vector3(-1, -1, -1))
-                    shipGrabbableItemPos.Add(savedShipItemData.itemPosition);
-                if (savedShipItemData.itemScrapValue != -1)
-                    shipScrapValues.Add(savedShipItemData.itemScrapValue);
-                if (savedShipItemData.itemAdditionalSavedData != -1)
-                    shipItemSaveData.Add(savedShipItemData.itemAdditionalSavedData);
-            }
+            // TODO: Config option to disable this process preferably
+
+            List<SavedShipItemData> loadedShipItemData = GetConstructedSavedShipItemData(currentSaveFile.itemSaveData);
+            FixMismatchedSavedItemData(loadedShipItemData);
+            OverrideCurrentSaveFileItemData(loadedShipItemData);
         }
 
         internal static void OverrideCurrentSaveFileItemData(List<SavedShipItemData> savedShipItemDatas)
@@ -249,8 +87,7 @@ namespace LethalLevelLoader
             foreach (SavedShipItemData savedShipItemData in savedShipItemDatas)
             {
                 shipGrabbableItemIDs.Add(savedShipItemData.itemAllItemsListIndex);
-                if (savedShipItemData.itemPosition != new Vector3(-1,-1,-1))
-                    shipGrabbableItemPos.Add(savedShipItemData.itemPosition);
+                shipGrabbableItemPos.Add(savedShipItemData.itemPosition);
                 if (savedShipItemData.itemScrapValue != -1)
                     shipScrapValues.Add(savedShipItemData.itemScrapValue);
                 if (savedShipItemData.itemAdditionalSavedData != -1)
@@ -276,9 +113,282 @@ namespace LethalLevelLoader
                 ES3.Save<int[]>("shipItemSaveData", shipItemSaveData.ToArray(), currentSaveFileName);
         }
 
-        internal static Dictionary<int, SavedShipItemData> GetConstructedSavedShipItemData()
+        internal static void FixMismatchedSavedItemData(List<SavedShipItemData> savedShipItemDatas)
         {
-            Dictionary<int, SavedShipItemData> returnDict = new Dictionary<int, SavedShipItemData>();
+            Dictionary<int, AllItemsListItemData> itemDataDict = GetAllItemsListItemDataDict();
+
+            int firstMismatch = 0;
+
+            foreach (SavedShipItemData savedShipItemData in savedShipItemDatas)
+            {
+                int allitemsListIndex = savedShipItemData.itemAllItemsListIndex;
+                if (!itemDataDict.ContainsKey(savedShipItemData.itemAllItemsListIndex))
+                    break;
+
+                AllItemsListItemData itemData = savedShipItemData.itemAllItemsListData;
+                AllItemsListItemData newItemData = itemDataDict[allitemsListIndex];
+
+                if (newItemData.itemName != itemData.itemName)
+                    break;
+
+                firstMismatch++;
+            }
+
+            if (firstMismatch >= savedShipItemDatas.Count)
+                return;
+
+            for (int i = firstMismatch; i < savedShipItemDatas.Count; i++)
+            {
+                SavedShipItemData savedShipItemData = savedShipItemDatas[i];
+                int oldIndex = savedShipItemData.itemAllItemsListIndex;
+
+                int newIndex = FixAllItemsListIndex(savedShipItemData.itemAllItemsListData, itemDataDict);
+                savedShipItemData.itemAllItemsListIndex = newIndex;
+
+                if (itemDataDict.ContainsKey(newIndex))
+                {
+                    AllItemsListItemData newItemData = itemDataDict[newIndex];
+
+                    if (oldIndex != newIndex)
+                    {
+                        DebugHelper.Log($"Fixing Item ┌ {savedShipItemData.itemAllItemsListData.modName} ┬ {savedShipItemData.itemAllItemsListData.itemName} ┬ {savedShipItemData.itemAllItemsListData.itemObjectName} ┬ #{oldIndex}", DebugType.User);
+                        DebugHelper.Log($"     -----> └ {newItemData.modName                           } ┴ {newItemData.itemName                           } ┴ {newItemData.itemObjectName                           } ┴ #{newIndex}", DebugType.User);
+                    }
+
+                    savedShipItemData.itemAllItemsListData = newItemData;
+
+                    if (!newItemData.isScrap && savedShipItemData.itemScrapValue >= 0)
+                        savedShipItemData.itemScrapValue = -1;
+                    else if (newItemData.isScrap && savedShipItemData.itemScrapValue == -1)
+                        savedShipItemData.itemScrapValue = 0; // Could generate a fitting scrap value here if desired
+
+                    if (!newItemData.saveItemVariable && savedShipItemData.itemAdditionalSavedData >= 0)
+                        savedShipItemData.itemAdditionalSavedData = -1;
+                    else if (newItemData.saveItemVariable && savedShipItemData.itemAdditionalSavedData == -1)
+                        savedShipItemData.itemAdditionalSavedData = 0; // Might cause problems with some items but what are you gonna do
+                }
+                else
+                {
+                    DebugHelper.Log($"Removing Item: [ {savedShipItemData.itemAllItemsListData.modName} ][ {savedShipItemData.itemAllItemsListData.itemName} ][ {savedShipItemData.itemAllItemsListData.itemObjectName} ][ #{oldIndex}", DebugType.User);
+
+                    savedShipItemData.itemScrapValue = -1;
+                    savedShipItemData.itemAdditionalSavedData = -1;
+                }
+            }
+        }
+
+        internal static int FixAllItemsListIndex(AllItemsListItemData itemData, Dictionary<int, AllItemsListItemData> itemDataDict)
+        {
+            // Priorities (higher number = higher priority)
+
+            // Variable definitions:
+            //  itemObjectName         : The name of the item's asset file.
+            //  itemName               : The name of the item (field set in the item's ScriptableObject).
+            //  modName                : The name of the mod the item is from.
+            //  allItemsListIndex      : The items list index of this item.
+            //  modItemsListIndex      : The items list index of this item relative to the modName.
+            //  itemNameDuplicateIndex : The duplicate index of the item's itemName relative to the modName, e.g. if a mod has two items named "Item A" this will be 1 for the second.
+
+            // Formulas (matching variables):
+            //  64 -> modAuthor                          (Only if priority is >= 4)
+            //  32 -> modName                            (Only if priority is >= 4)
+            //  16 -> itemName & itemNameDuplicateIndex  (Exclusive with below)
+            //   8 -> itemName                           (Exclusive with above)
+            //   4 -> itemObjectName                     (Minimum to not be removed)
+            //   2 -> modItemsListIndex & modName        (Only if priority is < 4)
+            //   1 -> allItemsListIndex                  (Only if priority is < 4)
+
+            // Possible values:
+            // 116 -> modAuthor & modName & itemName & itemNameDuplicateIndex & itemObjectName
+            // 112 -> modAuthor & modName & itemName & itemNameDuplicateIndex
+            // 108 -> modAuthor & modName & itemName & itemObjectName
+            // 104 -> modAuthor & modName & itemName
+            // 100 -> modAuthor & modName & itemObjectName
+            //  84 -> modAuthor & itemName & itemNameDuplicateIndex & itemObjectName
+            //  80 -> modAuthor & itemName & itemNameDuplicateIndex
+            //  76 -> modAuthor & itemName & itemObjectName
+            //  72 -> modAuthor & itemName
+            //  68 -> modAuthor & itemObjectName
+            //  52 -> modName & itemName & itemNameDuplicateIndex & itemObjectName
+            //  48 -> modName & itemName & itemNameDuplicateIndex
+            //  44 -> modName & itemName & itemObjectName 
+            //  40 -> modName & itemName
+            //  36 -> modName & itemObjectName
+            //  20 -> itemName & itemNameDuplicateIndex & itemObjectName
+            //  16 -> itemName & itemNameDuplicateIndex
+            //  12 -> itemName & itemObjectName
+            //   8 -> itemName
+            //   4 -> itemObjectName
+            // Low values (removed by default):
+            //   3 -> modItemsListIndex & modName & allitemsListIndex
+            //   2 -> modItemsListIndex & modName
+            //   1 -> allItemsListIndex
+
+            List<Item> allItemsList = Patches.StartOfRound.allItemsList.itemsList;
+
+            int matchedPriority = 0;
+            int matchedIndex = -1;
+
+            for (int newIndex = 0; newIndex < allItemsList.Count; newIndex++)
+            {
+                if (!itemDataDict.ContainsKey(newIndex))
+                    break;
+
+                int currentPriority = 0;
+                AllItemsListItemData newItemData = itemDataDict[newIndex];
+
+                if (newItemData.itemName == itemData.itemName)
+                    if (newItemData.itemNameDuplicateIndex == itemData.itemNameDuplicateIndex)
+                        currentPriority += 16;
+                    else
+                        currentPriority += 8;
+
+                if (newItemData.itemObjectName == itemData.itemObjectName)
+                    currentPriority += 4;
+
+                if (currentPriority >= 4)
+                {
+                    if (newItemData.modAuthor == itemData.modAuthor)
+                        currentPriority += 64;
+
+                    if (CompareModNames(newItemData.modName, itemData.modName))
+                        currentPriority += 32;
+                }
+                else
+                {
+                    if (newItemData.modItemsListIndex == itemData.modItemsListIndex && CompareModNames(newItemData.modName, itemData.modName))
+                        currentPriority += 2;
+
+                    if (newItemData.allItemsListIndex == itemData.allItemsListIndex)
+                        currentPriority += 1;
+                }
+
+                if (currentPriority > matchedPriority)
+                {
+                    matchedPriority = currentPriority;
+                    matchedIndex = newIndex;
+
+                    if (matchedPriority == 64 + 32 + 16 + 4) // Max value
+                        return matchedIndex;
+                }
+            }
+
+            // TODO: Config option to disable removing items that aren't name matched?  
+            if (matchedPriority >= 4)
+                return matchedIndex;
+            else
+                return int.MaxValue; // Use MaxValue since vanilla loading code checks upper bounds
+        }
+
+        internal static Dictionary<int, AllItemsListItemData> GetAllItemsListItemDataDict()
+        {
+            Dictionary<int, AllItemsListItemData> items = new Dictionary<int, AllItemsListItemData>();
+            int counter = 0;
+            foreach (Item item in Patches.StartOfRound.allItemsList.itemsList)
+            {
+                TryGetExtendedItemInfo(item, out string modName, out string modAuthor, out int modItemIndex);
+                int itemNameDuplicateIndex = GetItemNameDuplicateIndex(item, modName);
+
+                items.Add(counter, new AllItemsListItemData(item.name, item.itemName, modName, modAuthor, counter, modItemIndex, itemNameDuplicateIndex, item.isScrap, item.saveItemVariable));
+                counter++;
+            }
+
+            return (items);
+        }
+
+        internal static bool TryGetExtendedItemInfo(Item item, out string modName, out string modAuthor, out int modItemIndex)
+        {
+            int lowestNameAliases = int.MaxValue;
+            modName = "";
+            modAuthor = "";
+            modItemIndex = -1;
+
+            foreach (ExtendedMod extendedMod in PatchedContent.ExtendedMods)
+            {
+                if (lowestNameAliases <= extendedMod.ModNameAliases.Count)
+                    continue;
+
+                int modCounter = 0;
+
+                foreach (ExtendedItem extendedItem in extendedMod.ExtendedItems)
+                {
+                    if (extendedItem.Item == item)
+                    {
+                        modName = string.Join(';', extendedMod.ModNameAliases);
+                        modAuthor = extendedMod.AuthorName;
+                        modItemIndex = modCounter;
+
+                        lowestNameAliases = extendedMod.ModNameAliases.Count;
+                        break;
+                    }
+                    modCounter++;
+                }
+            }
+
+            return modItemIndex > -1;
+        }
+
+        internal static int GetItemNameDuplicateIndex(Item item, string modName)
+        {
+            if (modName != "")
+            {
+                foreach (ExtendedMod extendedMod in PatchedContent.ExtendedMods)
+                    if (CompareModNames(extendedMod.ModName, modName))
+                    {
+                        int modCounter = 0;
+
+                        foreach (ExtendedItem extendedItem in extendedMod.ExtendedItems)
+                            if (extendedItem.Item == item)
+                                break;
+                            else if (extendedItem.Item.itemName == item.itemName)
+                                modCounter++;
+
+                        return modCounter;
+                    }
+
+                return 0;
+            }
+            else
+            {
+                int counter = 0;
+
+                foreach (Item newItem in Patches.StartOfRound.allItemsList.itemsList)
+                    if (newItem == item)
+                        break;
+                    else if (newItem.itemName == item.itemName && !TryGetExtendedItemInfo(item, out _, out _, out _))
+                        counter++;
+
+                return counter;
+            }
+        }
+
+        internal static bool CompareModNames(string modNameA, string modNameB)
+        {
+            var modNamesA = modNameA.Split(';');
+            var modNamesB = modNameB.Split(';');
+
+            return modNamesA.Intersect(modNamesB).Any();
+        }
+
+        internal static List<AllItemsListItemData> GetAllItemsListItemDatas(List<int> itemIDs, Dictionary<int, AllItemsListItemData> itemDataDict)
+        {
+            List<AllItemsListItemData> result = new List<AllItemsListItemData>();
+
+            foreach (int id in itemIDs)
+            {
+                if (itemDataDict.ContainsKey(id))
+                    result.Add(itemDataDict[id]);
+                else
+                    // Don't know this item somehow? Add empty junk
+                    result.Add(new AllItemsListItemData("", "", "", "", id, -1, 0, false, false));
+            }
+
+            return (result);
+        }
+
+        internal static List<SavedShipItemData> GetConstructedSavedShipItemData(Dictionary<int, AllItemsListItemData> itemDataDict)
+        {
+            List<SavedShipItemData> result = new List<SavedShipItemData>();
 
             string currentSaveFileName = GameNetworkManager.Instance.currentSaveFileName;
 
@@ -307,27 +417,46 @@ namespace LethalLevelLoader
             else
                 shipItemSaveData = new List<int>();
 
+            List<AllItemsListItemData> shipGrabbableItemData = GetAllItemsListItemDatas(shipGrabbableItemIDs, itemDataDict);
+
+            int scrapValueIndex = 0;
+            int saveDataIndex = 0;
+
             for (int i = 0; i < shipGrabbableItemIDs.Count; i++)
             {
                 int newGrabbableItemID = shipGrabbableItemIDs[i];
-                Vector3 newGrabbableItemPos = new Vector3(-1, -1, -1);
+                Vector3 newGrabbableItemPos = Vector3.zero;
                 int newShipScrapValue = -1;
                 int newShipItemSaveData = -1;
+                AllItemsListItemData newGrabbableItemData = shipGrabbableItemData[i];
 
                 if (shipGrabbableItemPos.Count > i)
                     newGrabbableItemPos = shipGrabbableItemPos[i];
-                if (shipScrapValues.Count > i)
-                    newShipScrapValue = shipScrapValues[i];
-                if (shipItemSaveData.Count > i)
-                    newShipItemSaveData = shipItemSaveData[i];
 
-                returnDict.Add(newGrabbableItemID, new SavedShipItemData(newGrabbableItemID, newGrabbableItemPos, newShipScrapValue, newShipItemSaveData));
+                if (newGrabbableItemData.isScrap)
+                {
+                    if (shipScrapValues.Count > scrapValueIndex)
+                        newShipScrapValue = shipScrapValues[scrapValueIndex];
+                    else
+                        newShipScrapValue = 0;
+
+                    scrapValueIndex++;
+                }
+
+                if (newGrabbableItemData.saveItemVariable)
+                {
+                    if (shipItemSaveData.Count > saveDataIndex)
+                        newShipItemSaveData = shipItemSaveData[saveDataIndex];
+                    else
+                        newShipItemSaveData = 0;
+
+                    saveDataIndex++;
+                }
+
+                result.Add(new SavedShipItemData(newGrabbableItemID, newGrabbableItemPos, newShipScrapValue, newShipItemSaveData, newGrabbableItemData));
             }
 
-            if (returnDict.Count == 0)
-                DebugHelper.LogWarning("GetConstructedSavedShipItemData() Returning Empty Dict!", DebugType.User);
-
-            return (returnDict);
+            return (result);
         }
     }
 
@@ -337,27 +466,15 @@ namespace LethalLevelLoader
         public Vector3 itemPosition;
         public int itemScrapValue;
         public int itemAdditionalSavedData;
+        public AllItemsListItemData itemAllItemsListData;
 
-        public SavedShipItemData(int newItemAllItemsListIndex, Vector3 newItemPosition, int newItemScrapValue, int newItemAdditionalSavedData)
+        public SavedShipItemData(int newItemAllItemsListIndex, Vector3 newItemPosition, int newItemScrapValue, int newItemAdditionalSavedData, AllItemsListItemData newItemAllItemsListData)
         {
             itemAllItemsListIndex = newItemAllItemsListIndex;
             itemPosition = newItemPosition;
             itemScrapValue = newItemScrapValue;
             itemAdditionalSavedData = newItemAdditionalSavedData;
+            itemAllItemsListData = newItemAllItemsListData;
         }
     }
-
-        public struct ProcessedData
-        {
-            public List<int> validIndicies;
-            public Dictionary<int, int> recoveredIndicies;
-            public List<int> invalidIndicies;
-
-            public ProcessedData(List<int> newValidIndicies, Dictionary<int,int> newRecoveredIndicies,  List<int> newInvalidIndicies)
-            {
-                validIndicies = newValidIndicies;
-                recoveredIndicies = newRecoveredIndicies;
-                invalidIndicies = newInvalidIndicies;
-            }
-        }
 }

--- a/LethalLevelLoader/Patches/TerminalManager.cs
+++ b/LethalLevelLoader/Patches/TerminalManager.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http.Headers;
 using Unity.Netcode;
-using UnityEditor.Experimental.GraphView;
 using UnityEngine;
 using UnityEngine.InputSystem;
 

--- a/LethalLevelLoader/Tools/Validators.cs
+++ b/LethalLevelLoader/Tools/Validators.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 using Unity.Netcode;
-using UnityEditor.ShaderKeywordFilter;
 using UnityEngine;
 
 namespace LethalLevelLoader


### PR DESCRIPTION
Implemented the system to attempt to prevent item corruption by saving additional information for each item, aside from just their sequential IDs. This hasn't been fully tested with LLL mod item behaviour; there's a lot involved with that which is hard to test without many mods currently implementing scrap using LLL's systems.

This saves a bunch of additional values tied to each item sequential ID and, if it finds out a saved item doesn't load with the same name as before, goes through and fixes every item ID based on a scoring system where a bunch of these saved values are matched together, and they add up to a score which certain variables are much more important to - it then replaces the item's ID with the highest scored one (or, if the score is low enough, just removes the item altogether).

There's probably bound to be some flaw in the system I haven't found yet; an option to toggle this functionality would be good, but I'm not sure how you'd prefer to set that up. If you'd like to implement that yourself, returning early in `SaveManager.LoadShipGrabbableItems` to cancel the process would do the trick.

There's also a few general adjustments to saves:
- New "parityStepsTaken" saves the "StepsTaken" stat which is also saved in the vanilla file and, when loading, if they aren't the same value, any loading of LLLSaveFile values will be cancelled since the LLLSaveFile may be out-of-date
- The LLLSaveFile class doesn't need a prefix since that's auto-defined, and would have prevented LLL save data from loading if the save was renamed
- "CurrentLevelName" now only saves to the file when the rest of the game saves to the file