### PR TITLE
Fixed "Not being able to route to The Company Moon" issue #91, #83 , #80 , #78, #77

### DIFF
--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedLevel.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedLevel.cs
@@ -186,14 +186,11 @@ namespace LethalLevelLoader
 
         internal void SetLevelID()
         {
-            if (ContentType == ContentType.Custom)
-            {
-                SelectableLevel.levelID = PatchedContent.ExtendedLevels.IndexOf(this);
-                if (RouteNode != null)
-                    RouteNode.displayPlanetInfo = SelectableLevel.levelID;
-                if (RouteConfirmNode != null)
-                    RouteConfirmNode.buyRerouteToMoon = SelectableLevel.levelID;
-            }
+            SelectableLevel.levelID = PatchedContent.ExtendedLevels.IndexOf(this);
+            if (RouteNode != null)
+                RouteNode.displayPlanetInfo = SelectableLevel.levelID;
+            if (RouteConfirmNode != null)
+                RouteConfirmNode.buyRerouteToMoon = SelectableLevel.levelID;
         }
 
         internal void SetExtendedDungeonFlowMatches()

--- a/LethalLevelLoader/General/Patches.cs
+++ b/LethalLevelLoader/General/Patches.cs
@@ -196,7 +196,7 @@ namespace LethalLevelLoader
                 //Initialize ExtendedContent Objects For Custom Content.
                 AssetBundleLoader.InitializeBundles();
 
-                foreach (ExtendedLevel extendedLevel in PatchedContent.CustomExtendedLevels)
+                foreach (ExtendedLevel extendedLevel in PatchedContent.ExtendedLevels)
                     extendedLevel.SetLevelID();
 
                 //Some Debugging.

--- a/LethalLevelLoader/Tools/AssetBundleLoader.cs
+++ b/LethalLevelLoader/Tools/AssetBundleLoader.cs
@@ -472,13 +472,22 @@ namespace LethalLevelLoader
                 ExtendedLevel extendedLevel = ExtendedLevel.Create(selectableLevel);
 
                 foreach (CompatibleNoun compatibleRouteNoun in TerminalManager.routeKeyword.compatibleNouns)
-                    if (compatibleRouteNoun.noun.name.Contains(ExtendedLevel.GetNumberlessPlanetName(selectableLevel)))
+                {
+                    
+                    string comparedName = compatibleRouteNoun.noun.name;
+                    switch(comparedName)
+                    {
+                        // Terminal node noun is called "CompanyMoon", not "Gordion" so it will never grab the respective nodes if we don't change the compared name
+                        case "CompanyMoon": comparedName = "Gordion"; break;
+                    }
+                    if (comparedName.Contains(ExtendedLevel.GetNumberlessPlanetName(selectableLevel)))
                     {
                         extendedLevel.RouteNode = compatibleRouteNoun.result;
                         extendedLevel.RouteConfirmNode = compatibleRouteNoun.result.terminalOptions[1].result;
                         extendedLevel.RoutePrice = compatibleRouteNoun.result.itemCost;
                         break;
                     }
+                }
                 PatchedContent.AllLevelSceneNames.Add(extendedLevel.SelectableLevel.sceneName);
 
                 extendedLevel.Initialize("Lethal Company", generateTerminalAssets: false);


### PR DESCRIPTION
- ``ExtendedLevel.cs``
  - Removed the restriction of applying the terminal node changes on custom levels only.
  - Reasoning being that it's easier for every level to follow a standard rather than having special cases (CompanyRoute having a displayPlanetInfo of -1, leading to OutOfBounds).

- ``General/Patches.cs``
  - Changed applying the ``SetLevelID()`` method from ``CustomExtendedLevels`` to ``ExtendedLevels`` to include the vanilla moons as well.

- ``AssetBundleLoader.cs``
  - Added case to acquire the terminal nodes associated to the Company Moon due to the noun object name being ``CompanyMoon`` rather than ``Gordion``.
  
  Fixes  #91, fixes #83, fixes #80, fixes #78, and fixes #77 