### PR TITLE
Mold ID Modification: from ID to Level Name

### DIFF
--- a/LethalLevelLoader/General/Patches.cs
+++ b/LethalLevelLoader/General/Patches.cs
@@ -38,18 +38,13 @@ namespace LethalLevelLoader
         public static Terminal Terminal { get; internal set; }
         public static TimeOfDay TimeOfDay { get; internal set; }
 
-        private static readonly List<IDetour> monomodHooks = [];
+        private static readonly HookHelper.DisposableHookCollection monomodHooks = new();
         internal static void InitMonoModHooks()
         {
-            var method_GameNetworkManager_SaveGameValues = AccessTools.DeclaredMethod(typeof(GameNetworkManager), nameof(GameNetworkManager.SaveGameValues));
-            var method_GameNetworkManager_ResetSavedGameValues = AccessTools.DeclaredMethod(typeof(GameNetworkManager), nameof(GameNetworkManager.ResetSavedGameValues));
-            var method_StartOfRound_LoadPlanetsMoldSpreadData = AccessTools.DeclaredMethod(typeof(StartOfRound), nameof(StartOfRound.LoadPlanetsMoldSpreadData));
-            var method_MoldSpreadManager_Start = AccessTools.DeclaredMethod(typeof(MoldSpreadManager), nameof(MoldSpreadManager.Start));
-
-            monomodHooks.Add(new ILHook(method_GameNetworkManager_SaveGameValues, MoldLevelID2LevelName_ILHook));
-            monomodHooks.Add(new ILHook(method_GameNetworkManager_ResetSavedGameValues, MoldLevelID2LevelName_ILHook));
-            monomodHooks.Add(new ILHook(method_StartOfRound_LoadPlanetsMoldSpreadData, MoldLevelID2LevelName_ILHook));
-            monomodHooks.Add(new ILHook(method_MoldSpreadManager_Start, MoldLevelID2LevelName_ILHook));
+            monomodHooks.ILHook<GameNetworkManager>(nameof(GameNetworkManager.SaveGameValues), MoldLevelID2LevelName_ILHook);
+            monomodHooks.ILHook<GameNetworkManager>(nameof(GameNetworkManager.ResetSavedGameValues), MoldLevelID2LevelName_ILHook);
+            monomodHooks.ILHook<StartOfRound>(nameof(StartOfRound.LoadPlanetsMoldSpreadData), MoldLevelID2LevelName_ILHook);
+            monomodHooks.ILHook<MoldSpreadManager>(nameof(MoldSpreadManager.Start), MoldLevelID2LevelName_ILHook);
         }
 
         /// <summary>

--- a/LethalLevelLoader/General/Patches.cs
+++ b/LethalLevelLoader/General/Patches.cs
@@ -38,53 +38,6 @@ namespace LethalLevelLoader
         public static Terminal Terminal { get; internal set; }
         public static TimeOfDay TimeOfDay { get; internal set; }
 
-        private static readonly HookHelper.DisposableHookCollection monomodHooks = new();
-        internal static void InitMonoModHooks()
-        {
-            monomodHooks.ILHook<GameNetworkManager>(nameof(GameNetworkManager.SaveGameValues), MoldLevelID2LevelName_ILHook);
-            monomodHooks.ILHook<GameNetworkManager>(nameof(GameNetworkManager.ResetSavedGameValues), MoldLevelID2LevelName_ILHook);
-            monomodHooks.ILHook<StartOfRound>(nameof(StartOfRound.LoadPlanetsMoldSpreadData), MoldLevelID2LevelName_ILHook);
-            monomodHooks.ILHook<MoldSpreadManager>(nameof(MoldSpreadManager.Start), MoldLevelID2LevelName_ILHook);
-        }
-
-        /// <summary>
-        /// A rather generic ILHook that modifies Mold level save data to use level name instead of ID,<br/>
-        /// as ID will not be consistent.
-        /// </summary>
-        /// <param name="il"></param>
-        private static void MoldLevelID2LevelName_ILHook(ILContext il)
-        {
-            DebugHelper.Log($"[{nameof(MoldLevelID2LevelName_ILHook)}] ILHooking method: {il.Body.Method.Name}", DebugType.Developer);
-            int dbgModificationsAmount = 0;
-            string dbgMatchedStr = "";
-
-            ILCursor c = new(il);
-            while (
-                c.TryGotoNext(MoveType.After,
-                    x => x.MatchLdstr(out dbgMatchedStr) && dbgMatchedStr.Contains("Mold"), // The save file key, e.g. "Level{0}Mold"
-                    x => true   // game has various ways of referencing StartOfRound, listed here purely for reference:
-                        || x.MatchLdloc(out _)                                                  // via local variable
-                        || x.MatchLdarg(0)                                                      // via 'this'
-                        || x.MatchCall<StartOfRound>("get_" + nameof(StartOfRound.Instance)),   // via StartOfRound.Instance
-                    x => x.MatchLdfld<StartOfRound>(nameof(StartOfRound.levels)),
-                    x => x.MatchLdloc(out _),
-                    x => x.MatchLdelemRef(),
-                    x => x.MatchLdfld<SelectableLevel>(nameof(SelectableLevel.levelID)),
-                    x => x.MatchBox<Int32>()
-                )
-            )
-            {
-                DebugHelper.Log($"Matched \"{dbgMatchedStr}\"", DebugType.Developer);
-                c.Index -= 2;
-                c.RemoveRange(2);
-                c.EmitDelegate<Func<SelectableLevel, object>>(selectableLevel =>
-                    { return selectableLevel.name; }
-                );
-                dbgModificationsAmount++;
-            }
-            DebugHelper.Log($"Modified {dbgModificationsAmount} save data level IDs to level names", DebugType.Developer);
-        }
-
         [HarmonyPriority(harmonyPriority)]
         [HarmonyPatch(typeof(PreInitSceneScript), "Awake")]
         [HarmonyPrefix]
@@ -812,5 +765,45 @@ namespace LethalLevelLoader
             return list.OrderBy(x => x, new DoorwayPairComparer()).Take(num);
         }
 
+        //IL Hook stuff to replace Mold related save data references to a Level's ID to instead the Level's Name. Credit to Hamunii.
+        private static readonly HookHelper.DisposableHookCollection monomodHooks = new();
+        internal static void InitMonoModHooks()
+        {
+            monomodHooks.ILHook<GameNetworkManager>(nameof(GameNetworkManager.SaveGameValues), ReplaceSavedMoldLevelIDsWithLevelNames_ILHook);
+            monomodHooks.ILHook<GameNetworkManager>(nameof(GameNetworkManager.ResetSavedGameValues), ReplaceSavedMoldLevelIDsWithLevelNames_ILHook);
+            monomodHooks.ILHook<StartOfRound>(nameof(StartOfRound.LoadPlanetsMoldSpreadData), ReplaceSavedMoldLevelIDsWithLevelNames_ILHook);
+            monomodHooks.ILHook<MoldSpreadManager>(nameof(MoldSpreadManager.Start), ReplaceSavedMoldLevelIDsWithLevelNames_ILHook);
+        }
+
+        private static void ReplaceSavedMoldLevelIDsWithLevelNames_ILHook(ILContext il)
+        {
+            int dbgModificationsAmount = 0;
+            string dbgMatchedStr = "";
+
+            ILCursor c = new(il);
+            while (
+                c.TryGotoNext(MoveType.After,
+                    x => x.MatchLdstr(out dbgMatchedStr) && dbgMatchedStr.Contains("Mold"), // The save file key, e.g. "Level{0}Mold"
+                    x => true   // game has various ways of referencing StartOfRound, listed here purely for reference:
+                        || x.MatchLdloc(out _)                                                  // via local variable
+                        || x.MatchLdarg(0)                                                      // via 'this'
+                        || x.MatchCall<StartOfRound>("get_" + nameof(StartOfRound.Instance)),   // via StartOfRound.Instance
+                    x => x.MatchLdfld<StartOfRound>(nameof(StartOfRound.levels)),
+                    x => x.MatchLdloc(out _),
+                    x => x.MatchLdelemRef(),
+                    x => x.MatchLdfld<SelectableLevel>(nameof(SelectableLevel.levelID)),
+                    x => x.MatchBox<Int32>()
+                )
+            )
+            {
+                c.Index -= 2;
+                c.RemoveRange(2);
+                c.EmitDelegate<Func<SelectableLevel, object>>(selectableLevel =>
+                    { return selectableLevel.name; }
+                );
+                dbgModificationsAmount++;
+            }
+            DebugHelper.Log($"Modified {dbgModificationsAmount} save data level IDs to level names", DebugType.Developer);
+        }
     }
 }

--- a/LethalLevelLoader/Plugin.cs
+++ b/LethalLevelLoader/Plugin.cs
@@ -69,6 +69,7 @@ namespace LethalLevelLoader
 
             ConfigLoader.BindGeneralConfigs();
 
+            Patches.InitMonoModHooks();
             //UnityEngine.Object.FindFirstObjectByType<GameObject>()
         }
 

--- a/LethalLevelLoader/Plugin.cs
+++ b/LethalLevelLoader/Plugin.cs
@@ -52,7 +52,9 @@ namespace LethalLevelLoader
             Harmony.PatchAll(typeof(Patches));
             Harmony.PatchAll(typeof(EventPatches));
             Harmony.PatchAll(typeof(SafetyPatches));
+			
             NetworkScenePatcher.Patch();
+			Patches.InitMonoModHooks();
 
             NetcodePatch();
 
@@ -69,7 +71,6 @@ namespace LethalLevelLoader
 
             ConfigLoader.BindGeneralConfigs();
 
-            Patches.InitMonoModHooks();
             //UnityEngine.Object.FindFirstObjectByType<GameObject>()
         }
 


### PR DESCRIPTION
Makes mold save data work more consistently with custom moons.

Notes:
- `Patches.InitMonoModHooks();` is called after Config stuff is read for developer logs.
- I used MonoMod ILHooks / `ILCursor`, since I don't know `CodeMatcher`.
    - While Harmony can also do MonoMod style ILHooks, I think they were kinda broken so I made this with pure MonoMod.
- I didn't really test this much to see if it breaks things, but from my limited testing, this does indeed change the ID to the level name.
- I did check that I do ILHook every relevant method, and that the modifications indeed apply for every instance found in the game code.