### PR TITLE
Introduce csproj.user file for DLL copy path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13654,3 +13654,6 @@ Unity/LethalCompanyProject/UserSettings/Layouts/default-2022.dwlt
 Unity/LethalCompanyProject/UserSettings/Search.settings
 
 bin/Debug/*
+
+# Exclusions
+!*template.csproj.user

--- a/LethalLevelLoader/LethalLevelLoader.csproj
+++ b/LethalLevelLoader/LethalLevelLoader.csproj
@@ -43,9 +43,4 @@
   <Exec Command="netcode-patch &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies-> '&quot;%(Identity)&quot;', ' ')" />
   </Target>
 
-  <Target Name="CopyToDebugProfile" AfterTargets="NetcodePatch" Condition="'$(Configuration)' == 'Debug'">
-    <Message Importance="high" Text="Copying To Lethal Company Dir" />
-    <Copy SourceFiles="$(TargetDir)LethalLevelLoader.dll" DestinationFolder="C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\BepInEx\plugins\LethalLevelLoader" />
-  </Target>
-  
 </Project>

--- a/LethalLevelLoader/LethalLevelLoader.csproj
+++ b/LethalLevelLoader/LethalLevelLoader.csproj
@@ -1,16 +1,39 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+
       <TargetFramework>netstandard2.1</TargetFramework>
       <AssemblyName>LethalLevelLoader</AssemblyName>
       <Description>A Custom API to support the manual and dynamic integration of custom levels and dungeons in Lethal Company.</Description>
-      <Version>1.1.0</Version>
+      <Version>1.3.0</Version>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
       <LangVersion>preview</LangVersion>
+
+      <PackageId>IAmBatby.$(AssemblyName)</PackageId>
+      <PackageReadmeFile>README.md</PackageReadmeFile>
+      <IsPackable>true</IsPackable>
+
+      <RootNamespace>$(AssemblyName)</RootNamespace>
+      <PackageIcon>icon.png</PackageIcon>
+
+      <PackageLicenseExpression>MIT</PackageLicenseExpression>
+      <RepositoryUrl>https://github.com/IAmBatby/LethalLevelLoader/</RepositoryUrl>
+      <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
+      <RepositoryType>git</RepositoryType>
+
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
       <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(ProjectDir)../README.md" Pack="true" PackagePath="/" />
+    <None Include="$(ProjectDir)../icon.png" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MinVer" Version="4.*" PrivateAssets="all" Private="false" />
   </ItemGroup>
 
   <ItemGroup>
@@ -26,7 +49,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2">
+    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -36,11 +59,40 @@
   <ItemGroup>
     <PackageReference Include="Evaisa.LethalLib" Version="0.16.0" />
     <PackageReference Include="MaxWasUnavailable.LethalModDataLib" Version="1.2.2" />
-    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="55.0.0-beta.0-ngd.0" Publicize="true" />
+    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="56.0.1-ngd.0" Publicize="true" />
   </ItemGroup>
 
   <Target Name="NetcodePatch" AfterTargets="PostBuildEvent">
-  <Exec Command="netcode-patch &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies-> '&quot;%(Identity)&quot;', ' ')" />
+    <Exec Command="netcode-patch &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies-> '&quot;%(Identity)&quot;', ' ')" />
   </Target>
 
+  <PropertyGroup>
+    <MinVerDefaultPreReleaseIdentifiers>dev</MinVerDefaultPreReleaseIdentifiers>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+  </PropertyGroup>
+
+  <Target Name="SetPluginVersion" BeforeTargets="AddGeneratedFile" DependsOnTargets="MinVer">
+      <PropertyGroup>
+          <PlainVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)</PlainVersion>
+          <BepInExPluginVersion>$(PlainVersion)</BepInExPluginVersion>
+      </PropertyGroup>
+  </Target>
+
+  <Target Name="SaveVersionAndNameToFiles" DependsOnTargets="SetPluginVersion">
+    <WriteLinesToFile File="$(ProjectDir)dist/name.txt" Lines="$(AssemblyName)" Overwrite="true" />
+    <WriteLinesToFile File="$(ProjectDir)dist/version.txt" Lines="$(PlainVersion)" Overwrite="true" />
+  </Target>
+
+  <Target Name="PackThunderstore" DependsOnTargets="NetcodePatch;SetPluginVersion;SaveVersionAndNameToFiles" AfterTargets="PostBuildEvent" Condition="$(Configuration) == 'Release'">
+
+    <MakeDir Directories="$(ProjectDir)../assets/bundles" Condition="!Exists('$(ProjectDir)../assets/bundles')" />
+
+    <Exec Command="dotnet tcli build --config-path $(ProjectDir)../assets/thunderstore.toml" />
+
+    <ItemGroup>
+        <FilesToRename Include="$(ProjectDir)dist/*IAmBatby-$(AssemblyName)-$(PlainVersion).zip" />
+    </ItemGroup>
+
+  </Target>
+  
 </Project>

--- a/LethalLevelLoader/LethalLevelLoader.template.csproj.user
+++ b/LethalLevelLoader/LethalLevelLoader.template.csproj.user
@@ -1,0 +1,16 @@
+<Project>
+    <!-- COPY PASTE THIS FILE AND REMOVE .template FROM THE FILE NAME
+        - This will become your personal extension to the csproj file -->
+
+    <!-- Local Variables - Modify if Needed -->
+    <PropertyGroup>
+        <!-- The path to where the DLL get copied to when building. Include the last slash '/' -->
+        <PluginsDirectory>%programfiles(x86)%/Steam/steamapps/Common/Lethal Company/BepInEx/plugins/</PluginsDirectory>
+    </PropertyGroup>
+
+    <!-- Copy to Plugin Directory for Quicker Testing -->
+    <Target Name="CopyToDebugProfile" AfterTargets="NetcodePatch">
+        <Message Importance="high" Text="Copying To Lethal Company Dir" />
+        <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PluginsDirectory)" />
+    </Target>
+</Project>

--- a/README.md
+++ b/README.md
@@ -42,7 +42,18 @@ This Mod is Likely To Be Incompataible with **LethalExpansion**, Due To The inhe
 * Custom StoryLog's
 * Custom Weather Effects (WIP)
 * Custom Footstep Surfaces (WIP)
- 
+
+**Contributing To LethalLevelLoader**
+--
+
+### Setup
+To start contributing to LLL, you can start by [forking](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) the repo.  
+Then, follow these steps:  
+1. Install [Unity Netcode Patcher](https://github.com/EvaisaDev/UnityNetcodePatcher) CLI tool: `dotnet tool install -g Evaisa.NetcodePatcher.Cli`  
+2. It's recommended to set up a `csproj.user` file based on the [LethalLevelLoader.template.csproj.user](/LethalLevelLoader/LethalLevelLoader.template.csproj.user) file to automate copying the mod's DLL file over to your location of choosing. *This file will be gitignored.*
+
+You should be now set up, and ready compile your fork of LethalLevelLoader on your machine!
+
 **Credits**
 --
 


### PR DESCRIPTION
Move DLL copying from main csproj file to a personal, gitignored csproj.user file, so the main csproj file doesn't have paths that don't apply for everyone.

Also I added a little section to the README.md file to explain how to deal with it, mostly