### PR TITLE
Enable nullable (and resolve most nullable warnings)

### DIFF
--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedBuyableVehicle.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedBuyableVehicle.cs
@@ -8,14 +8,14 @@ namespace LethalLevelLoader
     [CreateAssetMenu(fileName = "ExtendedBuyableVehicle", menuName = "Lethal Level Loader/Extended Content/ExtendedBuyableVehicle", order = 21)]
     public class ExtendedBuyableVehicle : ExtendedContent
     {
-        [field: SerializeField] public BuyableVehicle BuyableVehicle { get; set; }
+        [field: SerializeField] public BuyableVehicle BuyableVehicle { get; set; } = null!;
         [field: SerializeField] public string TerminalKeywordName { get; set; } = string.Empty;
 
         public int VehicleID { get; set; }
 
-        public TerminalNode VehicleBuyNode { get; set; }
-        public TerminalNode VehicleBuyConfirmNode { get; set; }
-        public TerminalNode VehicleInfoNode { get; set; }
+        public TerminalNode VehicleBuyNode { get; set; } = null!;
+        public TerminalNode VehicleBuyConfirmNode { get; set; } = null!;
+        public TerminalNode VehicleInfoNode { get; set; } = null!;
 
         internal static ExtendedBuyableVehicle Create(BuyableVehicle newBuyableVehicle)
         {

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedContent.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedContent.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using UnityEngine;
@@ -8,7 +9,7 @@ namespace LethalLevelLoader
 {
     public class ExtendedContent : ScriptableObject
     {
-        public ExtendedMod ExtendedMod { get; internal set; }
+        public ExtendedMod ExtendedMod { get; internal set; } = null!;
         public ContentType ContentType { get; internal set; } = ContentType.Vanilla;
         /*Obsolete*/ public List<string> ContentTagStrings { get; internal set; } = new List<string>();
         [field: SerializeField] public List<ContentTag> ContentTags { get; internal set; } = new List<ContentTag>();
@@ -30,7 +31,7 @@ namespace LethalLevelLoader
             return (false);
         }
 
-        public bool TryGetTag(string tag, out ContentTag returnTag)
+        public bool TryGetTag(string tag, [NotNullWhen(returnValue: true)] out ContentTag? returnTag)
         {
             returnTag = null;
             foreach (ContentTag contentTag in ContentTags)

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedDungeonFlow.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedDungeonFlow.cs
@@ -15,19 +15,19 @@ namespace LethalLevelLoader
     public class ExtendedDungeonFlow : ExtendedContent
     {
         [field: Header("General Settings")]
-        [field: SerializeField] public DungeonFlow DungeonFlow { get; set; }
+        [field: SerializeField] public DungeonFlow DungeonFlow { get; set; } = null!;
         [field: SerializeField] public string DungeonName { get; set; } = string.Empty;
         [field: SerializeField] public float MapTileSize { get; set; } = 1f;
-        [field: SerializeField] public AudioClip FirstTimeDungeonAudio { get; set; }
+        [field: SerializeField] public AudioClip FirstTimeDungeonAudio { get; set; } = null!;
 
         [field: Space(5)]
         [field: Header("Dynamic Injection Matching Settings")]
-        [field: SerializeField] public LevelMatchingProperties LevelMatchingProperties { get; set; }
+        [field: SerializeField] public LevelMatchingProperties LevelMatchingProperties { get; set; } = null!;
 
         [field: Space(5)]
         [field: Header("Extended Feature Settings")]
 
-        [field: SerializeField] public GameObject OverrideKeyPrefab { get; set; }
+        [field: SerializeField] public GameObject OverrideKeyPrefab { get; set; } = null!;
         [field: SerializeField] public List<SpawnableMapObject> SpawnableMapObjects { get; set; } = new List<SpawnableMapObject>();
         [field: SerializeField] public List<GlobalPropCountOverride> GlobalPropCountOverridesList { get; set; } = new List<GlobalPropCountOverride>();
 
@@ -49,8 +49,8 @@ namespace LethalLevelLoader
         [Obsolete] public float dungeonSizeMin = 1;
         [Obsolete] public float dungeonSizeMax = 1;
         [Obsolete][Range(0, 1)] public float dungeonSizeLerpPercentage = 1;
-        [Obsolete] public AudioClip dungeonFirstTimeAudio;
-        [Obsolete] public DungeonFlow dungeonFlow;
+        [Obsolete] public AudioClip? dungeonFirstTimeAudio;
+        [Obsolete] public DungeonFlow? dungeonFlow;
         [Obsolete] public string dungeonDisplayName = string.Empty;
         [Obsolete] public string contentSourceName = string.Empty;
         [Obsolete] public List<StringWithRarity> dynamicLevelTagsList = new List<StringWithRarity>();
@@ -65,11 +65,11 @@ namespace LethalLevelLoader
         public bool IsCurrentDungeon => (DungeonManager.CurrentExtendedDungeonFlow == this);
         [HideInInspector] public DungeonEvents DungeonEvents { get; internal set; } = new DungeonEvents();
 
-        internal static ExtendedDungeonFlow Create(DungeonFlow newDungeonFlow, AudioClip newFirstTimeDungeonAudio)
+        internal static ExtendedDungeonFlow Create(DungeonFlow newDungeonFlow, AudioClip? newFirstTimeDungeonAudio)
         {
             ExtendedDungeonFlow newExtendedDungeonFlow = ScriptableObject.CreateInstance<ExtendedDungeonFlow>();
             newExtendedDungeonFlow.DungeonFlow = newDungeonFlow;
-            newExtendedDungeonFlow.FirstTimeDungeonAudio = newFirstTimeDungeonAudio;
+            newExtendedDungeonFlow.FirstTimeDungeonAudio = newFirstTimeDungeonAudio!;
 
             if (newExtendedDungeonFlow.LevelMatchingProperties == null)
                 newExtendedDungeonFlow.LevelMatchingProperties = LevelMatchingProperties.Create(newExtendedDungeonFlow);

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedEnemyType.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedEnemyType.cs
@@ -12,27 +12,27 @@ namespace LethalLevelLoader
     {
         [field: Header("General Settings")]
 
-        [field: SerializeField] public EnemyType EnemyType { get; set; }
-        [field: SerializeField] public string EnemyDisplayName { get; set; }
+        [field: SerializeField] public EnemyType EnemyType { get; set; } = null!;
+        [field: SerializeField] public string EnemyDisplayName { get; set; } = null!;
 
         [field: Space(5)]
         [field: Header("Dynamic Injection Matching Settings")]
 
-        [field: SerializeField] public LevelMatchingProperties OutsideLevelMatchingProperties { get; set; }
-        [field: SerializeField] public LevelMatchingProperties DaytimeLevelMatchingProperties { get; set; }
+        [field: SerializeField] public LevelMatchingProperties OutsideLevelMatchingProperties { get; set; } = null!;
+        [field: SerializeField] public LevelMatchingProperties DaytimeLevelMatchingProperties { get; set; } = null!;
 
-        [field: SerializeField] public LevelMatchingProperties InsideLevelMatchingProperties { get; set; }
-        [field: SerializeField] public DungeonMatchingProperties InsideDungeonMatchingProperties { get; set; }
+        [field: SerializeField] public LevelMatchingProperties InsideLevelMatchingProperties { get; set; } = null!;
+        [field: SerializeField] public DungeonMatchingProperties InsideDungeonMatchingProperties { get; set; } = null!;
 
         [field: Space(5)]
         [field: Header("Terminal Bestiary Override Settings")]
 
         [field: SerializeField] [field: TextArea(2,20)] public string InfoNodeDescription { get; set; } = string.Empty;
-        [field: SerializeField] public VideoClip InfoNodeVideoClip { get; set; }
+        [field: SerializeField] public VideoClip? InfoNodeVideoClip { get; set; }
 
-        public ScanNodeProperties ScanNodeProperties { get; internal set; }
+        public ScanNodeProperties ScanNodeProperties { get; internal set; } = null!;
         public int EnemyID { get; internal set; }
-        public TerminalNode EnemyInfoNode { get; internal set; }
+        public TerminalNode? EnemyInfoNode { get; internal set; }
 
         public static ExtendedEnemyType Create(EnemyType enemyType, ExtendedMod extendedMod, ContentType contentType)
         {

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedFootstepSurface.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedFootstepSurface.cs
@@ -8,8 +8,8 @@ namespace LethalLevelLoader;
 [CreateAssetMenu(fileName = "ExtendedFootstepSurface", menuName = "Lethal Level Loader/Extended Content/ExtendedFootstepSurface", order = 27)]
 public class ExtendedFootstepSurface : ExtendedContent
 {
-    public FootstepSurface footstepSurface;
-    public List<Material> associatedMaterials;
-    public List<GameObject> associatedGameObjects;
+    public FootstepSurface? footstepSurface;
+    public List<Material>? associatedMaterials;
+    public List<GameObject>? associatedGameObjects;
     internal int arrayIndex;
 }

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedItem.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedItem.cs
@@ -10,15 +10,15 @@ namespace LethalLevelLoader
     {
         [field: Header("General Settings")]
 
-        [field: SerializeField] public Item Item { get; set; }
+        [field: SerializeField] public Item Item { get; set; } = null!;
         [field: SerializeField] public string PluralisedItemName { get; set; } = string.Empty;
         [field: SerializeField] public bool IsBuyableItem { get; set; }
 
         [field: Space(5)]
         [field: Header("Dynamic Injection Matching Settings")]
 
-        [field: SerializeField] public LevelMatchingProperties LevelMatchingProperties { get; set; }
-        [field: SerializeField] public DungeonMatchingProperties DungeonMatchingProperties { get; set; }
+        [field: SerializeField] public LevelMatchingProperties LevelMatchingProperties { get; set; } = null!;
+        [field: SerializeField] public DungeonMatchingProperties DungeonMatchingProperties { get; set; } = null!;
 
         [field: Space(5)]
         [field: Header("Terminal Store & Info Override Settings")]
@@ -27,9 +27,9 @@ namespace LethalLevelLoader
         [field: SerializeField] public string OverrideBuyNodeDescription { get; set; } = string.Empty;
         [field: SerializeField] public string OverrideBuyConfirmNodeDescription { get; set; } = string.Empty;
 
-        public TerminalNode BuyNode { get; internal set; }
-        public TerminalNode BuyConfirmNode { get; internal set; }
-        public TerminalNode BuyInfoNode { get; internal set; }
+        public TerminalNode? BuyNode { get; internal set; }
+        public TerminalNode? BuyConfirmNode { get; internal set; }
+        public TerminalNode? BuyInfoNode { get; internal set; }
 
         public int CreditsWorth
         {

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedLevel.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedLevel.cs
@@ -14,7 +14,7 @@ namespace LethalLevelLoader
     public class ExtendedLevel : ExtendedContent
     {
         [field: Header("General Settings")]
-        [field: SerializeField] public SelectableLevel SelectableLevel { get; set; }
+        [field: SerializeField] public SelectableLevel SelectableLevel { get; set; } = null!;
         [Space(5)] [SerializeField] private int routePrice = 0;
 
         [field: Header("Extended Feature Settings")]
@@ -22,7 +22,7 @@ namespace LethalLevelLoader
 
         [field: Space(5)]
 
-        [field: SerializeField] public GameObject OverrideQuicksandPrefab { get; set; }
+        [field: SerializeField] public GameObject OverrideQuicksandPrefab { get; set; } = null!;
 
         [field: Space(5)]
 
@@ -32,8 +32,8 @@ namespace LethalLevelLoader
 
         [field: Space(5)]
 
-        [field: SerializeField] public AnimationClip ShipFlyToMoonClip { get; set; }
-        [field: SerializeField] public AnimationClip ShipFlyFromMoonClip { get; set; }
+        [field: SerializeField] public AnimationClip ShipFlyToMoonClip { get; set; } = null!;
+        [field: SerializeField] public AnimationClip ShipFlyFromMoonClip { get; set; } = null!;
 
         [field: Space(5)]
 
@@ -53,7 +53,7 @@ namespace LethalLevelLoader
 
         [Space(25)]
         [Header("Obsolete (Legacy Fields, Will Be Removed In The Future)")]
-        [Obsolete] public SelectableLevel selectableLevel;
+        [Obsolete] public SelectableLevel? selectableLevel;
         [Obsolete][Space(5)] public string contentSourceName = string.Empty; //Levels from AssetBundles will have this as their Assembly Name.
         [Obsolete][Space(5)] public List<string> levelTags = new List<string>();
 
@@ -94,13 +94,13 @@ namespace LethalLevelLoader
 
         [HideInInspector] public LevelEvents LevelEvents { get; internal set; } = new LevelEvents();
 
-        public TerminalNode RouteNode { get; internal set; }
-        public TerminalNode RouteConfirmNode { get; internal set; }
-        public TerminalNode InfoNode { get; internal set; }
+        public TerminalNode RouteNode { get; internal set; } = null!;
+        public TerminalNode RouteConfirmNode { get; internal set; } = null!;
+        public TerminalNode InfoNode { get; internal set; } = null!;
 
         //Dunno about these yet
         public List<ExtendedWeatherEffect> EnabledExtendedWeatherEffects { get; set; } = new List<ExtendedWeatherEffect>();
-        public ExtendedWeatherEffect CurrentExtendedWeatherEffect { get; set; }
+        public ExtendedWeatherEffect? CurrentExtendedWeatherEffect { get; set; }
 
         internal static ExtendedLevel Create(SelectableLevel newSelectableLevel)
         {
@@ -199,14 +199,14 @@ namespace LethalLevelLoader
         internal void SetExtendedDungeonFlowMatches()
         {
             foreach (IntWithRarity intWithRarity in SelectableLevel.dungeonFlowTypes)
-                if (DungeonManager.TryGetExtendedDungeonFlow(Patches.RoundManager.dungeonFlowTypes[intWithRarity.id].dungeonFlow, out ExtendedDungeonFlow extendedDungeonFlow))
+                if (DungeonManager.TryGetExtendedDungeonFlow(Patches.RoundManager.dungeonFlowTypes[intWithRarity.id].dungeonFlow, out ExtendedDungeonFlow? extendedDungeonFlow))
                     extendedDungeonFlow.LevelMatchingProperties.planetNames.Add(new StringWithRarity(NumberlessPlanetName, intWithRarity.rarity));
 
 
             if (SelectableLevel.sceneName == "Level4March")
                 foreach (IndoorMapType indoorMapType in Patches.RoundManager.dungeonFlowTypes)
                     if (indoorMapType.dungeonFlow.name == "Level1Flow3Exits")
-                        if (DungeonManager.TryGetExtendedDungeonFlow(indoorMapType.dungeonFlow, out ExtendedDungeonFlow marchDungeonFlow))
+                        if (DungeonManager.TryGetExtendedDungeonFlow(indoorMapType.dungeonFlow, out ExtendedDungeonFlow? marchDungeonFlow))
                             marchDungeonFlow.LevelMatchingProperties.planetNames.Add(new StringWithRarity(NumberlessPlanetName, 300));
         }
 

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedWeatherEffect.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedWeatherEffect.cs
@@ -14,8 +14,8 @@ namespace LethalLevelLoader
         [field: SerializeField] public LevelWeatherType BaseWeatherType { get; set; } = LevelWeatherType.None;
         [field: SerializeField] public string WeatherDisplayName { get; set; } = string.Empty;
 
-        [field: SerializeField] public GameObject WorldObject { get; set; }
-        [field: SerializeField] public GameObject GlobalObject { get; set; }
+        [field: SerializeField] public GameObject? WorldObject { get; set; }
+        [field: SerializeField] public GameObject? GlobalObject { get; set; }
 
         public ContentType contentType;
 
@@ -29,7 +29,7 @@ namespace LethalLevelLoader
             return (ExtendedWeatherEffect.Create(levelWeatherType, weatherEffect.effectObject, weatherEffect.effectPermanentObject, weatherDisplayName, newContentType));
         }
 
-        internal static ExtendedWeatherEffect Create(LevelWeatherType levelWeatherType, GameObject worldObject, GameObject globalObject, string newWeatherDisplayName, ContentType newContentType)
+        internal static ExtendedWeatherEffect Create(LevelWeatherType levelWeatherType, GameObject? worldObject, GameObject? globalObject, string newWeatherDisplayName, ContentType newContentType)
         {
             ExtendedWeatherEffect newExtendedWeatherEffect = ScriptableObject.CreateInstance<ExtendedWeatherEffect>();
 

--- a/LethalLevelLoader/Components/LLLSaveFile.cs
+++ b/LethalLevelLoader/Components/LLLSaveFile.cs
@@ -7,7 +7,7 @@ namespace LethalLevelLoader
 {
     public class LLLSaveFile : ModDataContainer
     {
-        public string? CurrentLevelName { get; internal set; } = string.Empty;
+        public string CurrentLevelName { get; internal set; } = string.Empty;
 
         public int parityStepsTaken;
         public Dictionary<int, AllItemsListItemData> itemSaveData = new Dictionary<int, AllItemsListItemData>();

--- a/LethalLevelLoader/Components/LLLSaveFile.cs
+++ b/LethalLevelLoader/Components/LLLSaveFile.cs
@@ -7,7 +7,7 @@ namespace LethalLevelLoader
 {
     public class LLLSaveFile : ModDataContainer
     {
-        public string CurrentLevelName { get; internal set; } = string.Empty;
+        public string? CurrentLevelName { get; internal set; } = string.Empty;
 
         public int parityStepsTaken;
         public Dictionary<int, AllItemsListItemData> itemSaveData = new Dictionary<int, AllItemsListItemData>();

--- a/LethalLevelLoader/Components/MatchingProperties/MatchingProperties.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/MatchingProperties.cs
@@ -18,7 +18,7 @@ namespace LethalLevelLoader
             return (matchingProperties);
         }
 
-        internal static bool UpdateRarity(ref int currentValue, int newValue, string debugActionObject = null, string debugActionReason = null)
+        internal static bool UpdateRarity(ref int currentValue, int newValue, string? debugActionObject = null, string? debugActionReason = null)
         {
             if (newValue > currentValue)
             {

--- a/LethalLevelLoader/General/Content.cs
+++ b/LethalLevelLoader/General/Content.cs
@@ -11,7 +11,7 @@ namespace LethalLevelLoader
 {
     public static class PatchedContent
     {
-        public static ExtendedMod VanillaMod { get; internal set; }
+        public static ExtendedMod VanillaMod { get; internal set; } = null!;
 
         public static List<string> AllLevelSceneNames { get; internal set; } = new List<string>();
 

--- a/LethalLevelLoader/General/EventPatches.cs
+++ b/LethalLevelLoader/General/EventPatches.cs
@@ -133,7 +133,7 @@ namespace LethalLevelLoader
             }
         }
 
-        private static EnemyVent cachedSelectedVent;
+        private static EnemyVent? cachedSelectedVent;
         [HarmonyPriority(Patches.harmonyPriority)]
         [HarmonyPatch(typeof(RoundManager), "SpawnEnemyFromVent")]
         [HarmonyPrefix]
@@ -285,7 +285,7 @@ namespace LethalLevelLoader
     public class ExtendedEvent<T>
     {
         public delegate void ParameterEvent(T param);
-        private event ParameterEvent onParameterEvent;
+        private event ParameterEvent? onParameterEvent;
         public bool HasListeners => (Listeners != 0);
         public int Listeners { get; internal set; }
         public void Invoke(T param) { onParameterEvent?.Invoke(param); }
@@ -296,7 +296,7 @@ namespace LethalLevelLoader
     public class ExtendedEvent
     {
         public delegate void Event();
-        private event Event onEvent;
+        private event Event? onEvent;
         public bool HasListeners => (Listeners != 0);
         public int Listeners { get; internal set; }
         public void Invoke() { onEvent?.Invoke(); }

--- a/LethalLevelLoader/General/Extensions.cs
+++ b/LethalLevelLoader/General/Extensions.cs
@@ -33,7 +33,7 @@ namespace LethalLevelLoader
 
             foreach (Tile tile in new List<Tile>(tilesList))
                 if (tile == null)
-                    tilesList.Remove(tile);
+                    tilesList.Remove(tile!);
 
             return (tilesList);
         }

--- a/LethalLevelLoader/General/Patches.cs
+++ b/LethalLevelLoader/General/Patches.cs
@@ -31,10 +31,10 @@ namespace LethalLevelLoader
         internal static List<string> allSceneNamesCalledToLoad = new List<string>();
 
         //Singletons and such for these are set in each classes Awake function, But they all are accessible on the first awake function of the earliest one of these four managers awake function, so i grab them directly via findobjectoftype to safely access them as early as possible.
-        public static StartOfRound StartOfRound { get; internal set; }
-        public static RoundManager RoundManager { get; internal set; }
-        public static Terminal Terminal { get; internal set; }
-        public static TimeOfDay TimeOfDay { get; internal set; }
+        public static StartOfRound StartOfRound { get; internal set; } = null!;
+        public static RoundManager RoundManager { get; internal set; } = null!;
+        public static Terminal Terminal { get; internal set; } = null!;
+        public static TimeOfDay TimeOfDay { get; internal set; } = null!;
 
         [HarmonyPriority(harmonyPriority)]
         [HarmonyPatch(typeof(PreInitSceneScript), "Awake")]
@@ -681,8 +681,8 @@ namespace LethalLevelLoader
             tempoarySpawnableMapObjectList.Clear();
         }
 
-        internal static GameObject previousHit;
-        internal static FootstepSurface previouslyAssignedFootstepSurface;
+        internal static GameObject? previousHit;
+        internal static FootstepSurface? previouslyAssignedFootstepSurface;
 
         [HarmonyPriority(harmonyPriority)]
         [HarmonyPatch(typeof(PlayerControllerB), "GetCurrentMaterialStandingOn")]

--- a/LethalLevelLoader/General/Patches.cs
+++ b/LethalLevelLoader/General/Patches.cs
@@ -425,7 +425,7 @@ namespace LethalLevelLoader
         {
             if (__result != null)
             {
-                TerminalKeyword newKeyword = TerminalManager.TryFindAlternativeNoun(__instance, __result, playerWord);
+                TerminalKeyword? newKeyword = TerminalManager.TryFindAlternativeNoun(__instance, __result, playerWord);
                 if (newKeyword != null)
                     __result = newKeyword;
             }

--- a/LethalLevelLoader/LethalLevelLoader.csproj
+++ b/LethalLevelLoader/LethalLevelLoader.csproj
@@ -7,6 +7,7 @@
       <Version>1.1.0</Version>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
       <LangVersion>preview</LangVersion>
+      <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">

--- a/LethalLevelLoader/Loaders/DungeonLoader.cs
+++ b/LethalLevelLoader/Loaders/DungeonLoader.cs
@@ -27,7 +27,7 @@ namespace LethalLevelLoader
 
     public static class DungeonLoader
     {
-        internal static GameObject defaultKeyPrefab;
+        internal static GameObject defaultKeyPrefab = null!;
         
         internal static void SelectDungeon()
         {
@@ -100,7 +100,7 @@ namespace LethalLevelLoader
         {
             string debugString = "Fire Exit Patch Report, Details Below;" + "\n" + "\n";
 
-            if (DungeonManager.TryGetExtendedDungeonFlow(dungeonGenerator.DungeonFlow, out ExtendedDungeonFlow extendedDungeonFlow))
+            if (DungeonManager.TryGetExtendedDungeonFlow(dungeonGenerator.DungeonFlow, out ExtendedDungeonFlow? extendedDungeonFlow))
             {
                 List<EntranceTeleport> entranceTeleports = GetEntranceTeleports(scene).OrderBy(o => o.entranceId).ToList();
 

--- a/LethalLevelLoader/Loaders/LevelLoader.cs
+++ b/LethalLevelLoader/Loaders/LevelLoader.cs
@@ -16,11 +16,11 @@ namespace LethalLevelLoader
     {
         internal static List<MeshCollider> customLevelMeshCollidersList = new List<MeshCollider>();
 
-        internal static AnimatorOverrideController shipAnimatorOverrideController;
-        internal static AnimationClip defaultShipFlyToMoonClip;
-        internal static AnimationClip defaultShipFlyFromMoonClip;
+        internal static AnimatorOverrideController shipAnimatorOverrideController = null!;
+        internal static AnimationClip defaultShipFlyToMoonClip = null!;
+        internal static AnimationClip defaultShipFlyFromMoonClip = null!;
 
-        internal static GameObject defaultQuicksandPrefab;
+        internal static GameObject defaultQuicksandPrefab = null!;
 
         internal static async void EnableMeshColliders()
         {

--- a/LethalLevelLoader/Patches/DungeonManager.cs
+++ b/LethalLevelLoader/Patches/DungeonManager.cs
@@ -3,6 +3,7 @@ using DunGen.Graph;
 using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Events;
@@ -17,7 +18,7 @@ namespace LethalLevelLoader
             {
                 ExtendedDungeonFlow? returnFlow = null;
                 if (Patches.RoundManager != null && Patches.RoundManager.dungeonGenerator != null)
-                    if (TryGetExtendedDungeonFlow(Patches.RoundManager.dungeonGenerator.Generator.DungeonFlow, out ExtendedDungeonFlow flow))
+                    if (TryGetExtendedDungeonFlow(Patches.RoundManager.dungeonGenerator.Generator.DungeonFlow, out ExtendedDungeonFlow? flow))
                         returnFlow = flow;
                 return (returnFlow);
             }
@@ -119,7 +120,7 @@ namespace LethalLevelLoader
             Patches.RoundManager.dungeonFlowTypes = indoorMapTypes.ToArray();
         }
 
-        internal static bool TryGetExtendedDungeonFlow(DungeonFlow dungeonFlow, out ExtendedDungeonFlow? returnExtendedDungeonFlow, ContentType contentType = ContentType.Any)
+        internal static bool TryGetExtendedDungeonFlow(DungeonFlow dungeonFlow, [NotNullWhen(returnValue: true)] out ExtendedDungeonFlow? returnExtendedDungeonFlow, ContentType contentType = ContentType.Any)
         {
             returnExtendedDungeonFlow = null;
             List<ExtendedDungeonFlow> extendedDungeonFlowsList = null!;

--- a/LethalLevelLoader/Patches/DungeonManager.cs
+++ b/LethalLevelLoader/Patches/DungeonManager.cs
@@ -11,11 +11,11 @@ namespace LethalLevelLoader
 {
     public class DungeonManager
     {
-        public static ExtendedDungeonFlow CurrentExtendedDungeonFlow
+        public static ExtendedDungeonFlow? CurrentExtendedDungeonFlow
         {
             get
             {
-                ExtendedDungeonFlow returnFlow = null;
+                ExtendedDungeonFlow? returnFlow = null;
                 if (Patches.RoundManager != null && Patches.RoundManager.dungeonGenerator != null)
                     if (TryGetExtendedDungeonFlow(Patches.RoundManager.dungeonGenerator.Generator.DungeonFlow, out ExtendedDungeonFlow flow))
                         returnFlow = flow;
@@ -119,10 +119,10 @@ namespace LethalLevelLoader
             Patches.RoundManager.dungeonFlowTypes = indoorMapTypes.ToArray();
         }
 
-        internal static bool TryGetExtendedDungeonFlow(DungeonFlow dungeonFlow, out ExtendedDungeonFlow returnExtendedDungeonFlow, ContentType contentType = ContentType.Any)
+        internal static bool TryGetExtendedDungeonFlow(DungeonFlow dungeonFlow, out ExtendedDungeonFlow? returnExtendedDungeonFlow, ContentType contentType = ContentType.Any)
         {
             returnExtendedDungeonFlow = null;
-            List<ExtendedDungeonFlow> extendedDungeonFlowsList = null;
+            List<ExtendedDungeonFlow> extendedDungeonFlowsList = null!;
 
             if (dungeonFlow == null) return (false);
 
@@ -140,7 +140,7 @@ namespace LethalLevelLoader
             return (returnExtendedDungeonFlow != null);
         }
 
-        internal static bool TryGetExtendedDungeonFlow(IndoorMapType indoorMapType, out ExtendedDungeonFlow returnExtendedDungeonFlow, ContentType contentType = ContentType.Any)
+        internal static bool TryGetExtendedDungeonFlow(IndoorMapType indoorMapType, out ExtendedDungeonFlow? returnExtendedDungeonFlow, ContentType contentType = ContentType.Any)
         {
             return (TryGetExtendedDungeonFlow(indoorMapType.dungeonFlow, out returnExtendedDungeonFlow, contentType));
         }

--- a/LethalLevelLoader/Patches/EnemyManager.cs
+++ b/LethalLevelLoader/Patches/EnemyManager.cs
@@ -20,9 +20,9 @@ namespace LethalLevelLoader
             foreach (ExtendedEnemyType extendedEnemyType in PatchedContent.CustomExtendedEnemyTypes)
             {
                 string debugString = string.Empty;
-                SpawnableEnemyWithRarity alreadyInjectedInsideEnemy = null;
-                SpawnableEnemyWithRarity alreadyInjectedOutsideEnemy = null;
-                SpawnableEnemyWithRarity alreadyInjectedDaytimeEnemy = null;
+                SpawnableEnemyWithRarity? alreadyInjectedInsideEnemy;
+                SpawnableEnemyWithRarity? alreadyInjectedOutsideEnemy;
+                SpawnableEnemyWithRarity? alreadyInjectedDaytimeEnemy;
 
                 foreach (SpawnableEnemyWithRarity spawnableEnemyWithRarity in extendedLevel.SelectableLevel.Enemies)
                     if (spawnableEnemyWithRarity.enemyType == extendedEnemyType)
@@ -56,7 +56,7 @@ namespace LethalLevelLoader
 
         internal static bool TryInjectEnemyIntoPool(List<SpawnableEnemyWithRarity> enemyPool, ExtendedEnemyType extendedEnemy, int newRarity, out SpawnableEnemyWithRarity spawnableEnemyWithRarity)
         {
-            spawnableEnemyWithRarity = null;
+            spawnableEnemyWithRarity = null!;
             foreach (SpawnableEnemyWithRarity currentSpawnableEnemyWithRarity in enemyPool)
                 if (currentSpawnableEnemyWithRarity.enemyType == extendedEnemy.EnemyType)
                     spawnableEnemyWithRarity = currentSpawnableEnemyWithRarity;

--- a/LethalLevelLoader/Patches/ItemManager.cs
+++ b/LethalLevelLoader/Patches/ItemManager.cs
@@ -21,7 +21,7 @@ namespace LethalLevelLoader
                 if (extendedItem.Item.isScrap)
                 {
                     string debugString = string.Empty;
-                    SpawnableItemWithRarity alreadyInjectedItem = null;
+                    SpawnableItemWithRarity? alreadyInjectedItem = null;
                     foreach (SpawnableItemWithRarity spawnableItem in extendedLevel.SelectableLevel.spawnableScrap)
                         if (spawnableItem.spawnableItem == extendedItem)
                             alreadyInjectedItem = spawnableItem;

--- a/LethalLevelLoader/Patches/LethalLevelLoaderNetworkManager.cs
+++ b/LethalLevelLoader/Patches/LethalLevelLoaderNetworkManager.cs
@@ -14,8 +14,8 @@ namespace LethalLevelLoader
 {
     public class LethalLevelLoaderNetworkManager : NetworkBehaviour
     {
-        public static GameObject networkingManagerPrefab;
-        private static LethalLevelLoaderNetworkManager _instance;
+        public static GameObject networkingManagerPrefab = null!;
+        private static LethalLevelLoaderNetworkManager? _instance;
         public static LethalLevelLoaderNetworkManager Instance
         {
             get
@@ -24,11 +24,11 @@ namespace LethalLevelLoader
                     _instance = UnityEngine.Object.FindObjectOfType<LethalLevelLoaderNetworkManager>();
                 if (_instance == null)
                     DebugHelper.LogError("LethalLevelLoaderNetworkManager Could Not Be Found! Returning Null!", DebugType.User);
-                return _instance;
+                return _instance!;
             }
             set { _instance = value; }
         }
-        public static NetworkManager networkManager;
+        public static NetworkManager networkManager = null!;
 
         private static List<GameObject> queuedNetworkPrefabs = new List<GameObject>();
         public static bool networkHasStarted;
@@ -192,7 +192,7 @@ namespace LethalLevelLoader
 
         public class StringContainer : INetworkSerializable
         {
-            public string SomeText;
+            public string SomeText = null!;
             public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
             {
                 if (serializer.IsWriter)

--- a/LethalLevelLoader/Patches/SaveManager.cs
+++ b/LethalLevelLoader/Patches/SaveManager.cs
@@ -10,7 +10,7 @@ namespace LethalLevelLoader
 {
     internal static class SaveManager
     {
-        public static LLLSaveFile currentSaveFile;
+        public static LLLSaveFile currentSaveFile = null!;
         public static bool parityCheck;
 
         internal static void InitializeSave()
@@ -392,10 +392,10 @@ namespace LethalLevelLoader
 
             string currentSaveFileName = GameNetworkManager.Instance.currentSaveFileName;
 
-            List<int> shipGrabbableItemIDs = null;
-            List<Vector3> shipGrabbableItemPos = null;
-            List<int> shipScrapValues = null;
-            List<int> shipItemSaveData = null;
+            List<int> shipGrabbableItemIDs;
+            List<Vector3> shipGrabbableItemPos;
+            List<int> shipScrapValues;
+            List<int> shipItemSaveData;
 
             if (ES3.KeyExists("shipGrabbableItemIDs", currentSaveFileName))
                 shipGrabbableItemIDs = ES3.Load<int[]>("shipGrabbableItemIDs", currentSaveFileName).ToList();

--- a/LethalLevelLoader/Patches/TerminalManager.cs
+++ b/LethalLevelLoader/Patches/TerminalManager.cs
@@ -12,7 +12,7 @@ namespace LethalLevelLoader
 {
     public class TerminalManager
     {
-        private static Terminal _terminal;
+        private static Terminal? _terminal;
         internal static Terminal Terminal
         {
             get
@@ -24,30 +24,30 @@ namespace LethalLevelLoader
             }
         }
 
-        internal static TerminalNode lockedNode;
+        internal static TerminalNode lockedNode = null!;
 
-        public static MoonsCataloguePage defaultMoonsCataloguePage { get; internal set; }
-        public static MoonsCataloguePage currentMoonsCataloguePage { get; internal set; }
+        public static MoonsCataloguePage defaultMoonsCataloguePage { get; internal set; } = null!;
+        public static MoonsCataloguePage currentMoonsCataloguePage { get; internal set; } = null!;
 
         //Cached References To Important Base-Game TerminalKeywords;
-        internal static TerminalKeyword routeKeyword;
-        internal static TerminalKeyword routeInfoKeyword;
-        internal static TerminalKeyword routeConfirmKeyword;
-        internal static TerminalKeyword routeDenyKeyword;
-        internal static TerminalKeyword moonsKeyword;
-        internal static TerminalKeyword viewKeyword;
-        internal static TerminalKeyword buyKeyword;
-        internal static TerminalNode cancelRouteNode;
-        internal static TerminalNode cancelPurchaseNode;
+        internal static TerminalKeyword routeKeyword = null!;
+        internal static TerminalKeyword routeInfoKeyword = null!;
+        internal static TerminalKeyword routeConfirmKeyword = null!;
+        internal static TerminalKeyword routeDenyKeyword = null!;
+        internal static TerminalKeyword moonsKeyword = null!;
+        internal static TerminalKeyword viewKeyword = null!;
+        internal static TerminalKeyword buyKeyword = null!;
+        internal static TerminalNode cancelRouteNode = null!;
+        internal static TerminalNode cancelPurchaseNode = null!;
 
-        internal static string currentTagFilter;
+        internal static string currentTagFilter = null!;
 
         internal static float defaultTerminalFontSize;
 
-        internal static TerminalKeyword lastParsedVerbKeyword;
+        internal static TerminalKeyword? lastParsedVerbKeyword;
 
         public delegate string PreviewInfoText(ExtendedLevel extendedLevel, PreviewInfoType infoType);
-        public static event PreviewInfoText onBeforePreviewInfoTextAdded;
+        public static event PreviewInfoText? onBeforePreviewInfoTextAdded;
 
         //internal static Dictionary<TerminalNode, Action<TerminalNode, TerminalNode>> terminalNodeRegisteredEventDictionary = new Dictionary<TerminalNode, Action<TerminalNode, TerminalNode>>();
 
@@ -371,7 +371,7 @@ namespace LethalLevelLoader
             if (extendedLevel.IsRouteLocked == true)
                 levelPreviewInfo += " (Locked)";
 
-            string overridePreviewInfo = onBeforePreviewInfoTextAdded?.Invoke(extendedLevel, Settings.levelPreviewInfoType);
+            string? overridePreviewInfo = onBeforePreviewInfoTextAdded?.Invoke(extendedLevel, Settings.levelPreviewInfoType);
             if (overridePreviewInfo != null && overridePreviewInfo != string.Empty)
                 levelPreviewInfo = overridePreviewInfo;
 
@@ -391,7 +391,7 @@ namespace LethalLevelLoader
 
         public static string GetHistoryConditions(ExtendedLevel extendedLevel)
         {
-            DayHistory dayHistory = null;
+            DayHistory? dayHistory = null;
 
             foreach (DayHistory loggedDayHistory in LevelManager.dayHistoryList)
                 if (loggedDayHistory.extendedLevel == extendedLevel)
@@ -465,9 +465,9 @@ namespace LethalLevelLoader
             return returnString;
         }
 
-        internal static TerminalKeyword TryFindAlternativeNoun(Terminal terminal, TerminalKeyword foundKeyword, string playerInput)
+        internal static TerminalKeyword? TryFindAlternativeNoun(Terminal terminal, TerminalKeyword? foundKeyword, string playerInput)
         {
-            if (foundKeyword != null & terminal.hasGottenVerb == false && foundKeyword.isVerb == true)
+            if (foundKeyword != null && terminal.hasGottenVerb == false && foundKeyword.isVerb == true)
                 lastParsedVerbKeyword = foundKeyword;
 
             if (foundKeyword != null && foundKeyword.isVerb == false && terminal.hasGottenVerb == true && lastParsedVerbKeyword != null)
@@ -778,7 +778,7 @@ namespace LethalLevelLoader
             }
 
             //Terminal Info Node
-            TerminalNode terminalNodeInfo = null;
+            TerminalNode? terminalNodeInfo = null;
             if (!string.IsNullOrEmpty(extendedItem.OverrideInfoNodeDescription))
             {
                 if (extendedItem.BuyInfoNode != null)
@@ -931,16 +931,20 @@ namespace LethalLevelLoader
             return (CreateTerminalEventNodes(newVerbKeywordWord, convertedList));
         }
 
-        internal static List<TerminalNode> CreateTerminalEventNodes(string newVerbKeywordWord, List<string> nounWords, List<string> terminalEventStrings = null, bool createNewVerbKeyword = true)
+        internal static List<TerminalNode> CreateTerminalEventNodes(string newVerbKeywordWord, List<string> nounWords, List<string>? terminalEventStrings = null, bool createNewVerbKeyword = true)
         {
             List<TerminalNode> newTerminalNodes = new List<TerminalNode>();
-            TerminalKeyword verbKeyword = null;
+            TerminalKeyword? verbKeyword = null;
             if (createNewVerbKeyword == true)
                 verbKeyword = CreateNewTerminalKeyword();
             else
                 foreach (TerminalKeyword terminalKeyword in Terminal.terminalNodes.allKeywords)
                     if (terminalKeyword.isVerb == true && terminalKeyword.word == newVerbKeywordWord.ToLower())
-                        verbKeyword = terminalKeyword;  
+                        verbKeyword = terminalKeyword;
+
+            if (verbKeyword == null) // Should this throw? I left the possible NRE where it was, but with a clear message.
+                throw new NullReferenceException($"A new 'VerbKeyword' was not created, and an existing verb called '{newVerbKeywordWord}' wasn't found!");
+
             verbKeyword.word = newVerbKeywordWord.ToLower();
             verbKeyword.name = newVerbKeywordWord.ToLower() + "Keyword";
             verbKeyword.isVerb = true;

--- a/LethalLevelLoader/Plugin.cs
+++ b/LethalLevelLoader/Plugin.cs
@@ -24,18 +24,18 @@ namespace LethalLevelLoader
         public const string ModName = "LethalLevelLoader";
         public const string ModVersion = "1.3.0";
 
-        internal static Plugin Instance;
+        internal static Plugin Instance = null!;
 
-        internal static AssetBundle MainAssets;
+        internal static AssetBundle? MainAssets;
         internal static readonly Harmony Harmony = new Harmony(ModGUID);
 
-        internal static BepInEx.Logging.ManualLogSource logger;
+        internal static BepInEx.Logging.ManualLogSource logger = null!;
 
-        public static event Action onBeforeSetup;
-        public static event Action onSetupComplete;
+        public static event Action? onBeforeSetup;
+        public static event Action? onSetupComplete;
         public static bool IsSetupComplete { get; private set; } = false;
 
-        internal static GameObject networkManagerPrefab;
+        internal static GameObject? networkManagerPrefab;
 
         private void Awake()
         {

--- a/LethalLevelLoader/Tools/AssetBundleLoader.cs
+++ b/LethalLevelLoader/Tools/AssetBundleLoader.cs
@@ -23,22 +23,22 @@ namespace LethalLevelLoader
 {
     public class AssetBundleLoader : MonoBehaviour
     {
-        public static AssetBundleLoader Instance;
+        public static AssetBundleLoader Instance = null!;
 
-        internal Plugin pluginInstace;
+        internal Plugin? pluginInstace;
 
         public const string specifiedFileExtension = "*.lethalbundle";
 
         internal static DirectoryInfo lethalLibFile = new DirectoryInfo(Assembly.GetExecutingAssembly().Location);
-        internal static DirectoryInfo lethalLibFolder;
-        internal static DirectoryInfo pluginsFolder;
+        internal static DirectoryInfo lethalLibFolder = null!;
+        internal static DirectoryInfo pluginsFolder = null!;
 
         internal static Dictionary<string, ExtendedMod> obtainedExtendedModsDictionary = new Dictionary<string, ExtendedMod>();
 
         public enum LoadingStatus { Inactive, Loading, Complete };
         public static LoadingStatus CurrentLoadingStatus { get; internal set; } = LoadingStatus.Inactive;
 
-        internal static Dictionary<string, AssetBundle> assetBundles = new Dictionary<string, AssetBundle>(); 
+        internal static Dictionary<string, AssetBundle?> assetBundles = new Dictionary<string, AssetBundle?>(); 
         internal static Dictionary<string, string> assetBundleLoadTimes = new Dictionary<string, string>();
 
         internal static Dictionary<string, List<Action<AssetBundle>>> onLethalBundleLoadedRequestDictionary = new Dictionary<string, List<Action<AssetBundle>>>();
@@ -49,7 +49,7 @@ namespace LethalLevelLoader
             get
             {
                 bool bundlesFinishedLoading = true;
-                foreach (KeyValuePair<string, AssetBundle> assetBundle in assetBundles)
+                foreach (KeyValuePair<string, AssetBundle?> assetBundle in assetBundles)
                     if (assetBundle.Value == null)
                         bundlesFinishedLoading = false;
                 return (bundlesFinishedLoading);
@@ -61,7 +61,7 @@ namespace LethalLevelLoader
             get
             {
                 int bundlesFinishedLoading = 0;
-                foreach (KeyValuePair<string, AssetBundle> assetBundle in assetBundles)
+                foreach (KeyValuePair<string, AssetBundle?> assetBundle in assetBundles)
                     if (assetBundle.Value != null)
                         bundlesFinishedLoading++;
                 return (bundlesFinishedLoading);
@@ -69,12 +69,12 @@ namespace LethalLevelLoader
         }
 
         public delegate void BundlesFinishedLoading();
-        public static event BundlesFinishedLoading onBundlesFinishedLoading;
+        public static event BundlesFinishedLoading? onBundlesFinishedLoading;
 
         public delegate void BundleFinishedLoading(AssetBundle assetBundle);
-        public static event BundleFinishedLoading onBundleFinishedLoading;
+        public static event BundleFinishedLoading? onBundleFinishedLoading;
 
-        internal static TextMeshProUGUI loadingBundlesHeaderText;
+        internal static TextMeshProUGUI? loadingBundlesHeaderText;
 
         internal static bool noBundlesFound = false;
 
@@ -209,7 +209,7 @@ namespace LethalLevelLoader
         {
             DebugHelper.Log("Found ExtendedMod: " + extendedMod.name, DebugType.User);
             extendedMod.ModNameAliases.Add(extendedMod.ModName);
-            ExtendedMod matchingExtendedMod = null;
+            ExtendedMod? matchingExtendedMod = null;
             foreach (ExtendedMod registeredExtendedMod in obtainedExtendedModsDictionary.Values)
             {
                 if (extendedMod.ModMergeSetting == ModMergeSetting.MatchingModName && registeredExtendedMod.ModMergeSetting == ModMergeSetting.MatchingModName)
@@ -281,7 +281,7 @@ namespace LethalLevelLoader
             }
         }
 
-        public static void AddOnExtendedModLoadedListener(Action<ExtendedMod> invokedFunction, string extendedModAuthorName = null, string extendedModModName = null)
+        public static void AddOnExtendedModLoadedListener(Action<ExtendedMod> invokedFunction, string? extendedModAuthorName = null, string? extendedModModName = null)
         {
             if (invokedFunction != null && !string.IsNullOrEmpty(extendedModAuthorName))
             {
@@ -319,7 +319,7 @@ namespace LethalLevelLoader
             foreach (KeyValuePair<string, List<System.Action<AssetBundle>>> kvp in onLethalBundleLoadedRequestDictionary)
                 if (assetBundles.ContainsKey(kvp.Key))
                     foreach (Action<AssetBundle> action in kvp.Value)
-                        action(assetBundles[kvp.Key]);
+                        action(assetBundles[kvp.Key]!);
 
             foreach (KeyValuePair<string, List<Action<ExtendedMod>>> kvp in onExtendedModLoadedRequestDictionary)
                 foreach (ExtendedMod extendedMod in PatchedContent.ExtendedMods)
@@ -337,7 +337,7 @@ namespace LethalLevelLoader
                 return;
             }
 
-            ExtendedMod extendedMod = null;
+            ExtendedMod? extendedMod = null;
             if (extendedContent is ExtendedLevel extendedLevel)
             {
                 if (string.IsNullOrEmpty(extendedLevel.contentSourceName))
@@ -419,7 +419,7 @@ namespace LethalLevelLoader
                 {
                     foundExtendedLevelScene = false;
                     string debugString = "Could Not Find Scene File For ExtendedLevel: " + extendedLevel.SelectableLevel.name + ", Unregistering Early. \nSelectable Scene Name Is: " + extendedLevel.SelectableLevel.sceneName + ". Scenes Found In Bundles Are: " + "\n";
-                    foreach (KeyValuePair<string, AssetBundle> assetBundle in assetBundles)
+                    foreach (KeyValuePair<string, AssetBundle?> assetBundle in assetBundles)
                         if (assetBundle.Value != null && assetBundle.Value.isStreamedSceneAssetBundle)
                             foreach (string scenePath in assetBundle.Value.GetAllScenePaths())
                             {
@@ -604,7 +604,7 @@ namespace LethalLevelLoader
 
         internal static void CreateVanillaExtendedDungeonFlow(DungeonFlow dungeonFlow)
         {
-            AudioClip firstTimeDungeonAudio = null;
+            AudioClip? firstTimeDungeonAudio = null;
             string dungeonDisplayName = string.Empty;
 
             if (dungeonFlow.name.Contains("Level1"))
@@ -753,7 +753,7 @@ namespace LethalLevelLoader
 
         }
 
-        internal static void UpdateLoadingBundlesHeaderText(AssetBundle _)
+        internal static void UpdateLoadingBundlesHeaderText(AssetBundle? _)
         {
             if (loadingBundlesHeaderText != null)
             {

--- a/LethalLevelLoader/Tools/ConfigLoader.cs
+++ b/LethalLevelLoader/Tools/ConfigLoader.cs
@@ -14,7 +14,7 @@ namespace LethalLevelLoader.Tools
     {
         public static string debugLevelsString = string.Empty;
         public static string debugDungeonsString = string.Empty;
-        public static ConfigFile configFile;
+        public static ConfigFile configFile = null!;
 
         internal static void BindConfigs()
         {
@@ -74,14 +74,14 @@ namespace LethalLevelLoader.Tools
 
     public class GeneralSettingsConfig : ConfigTemplate
     {
-        private ConfigEntry<PreviewInfoType> previewInfoTypeToggle;
-        private ConfigEntry<SortInfoType> sortInfoTypeToggle;
-        private ConfigEntry<FilterInfoType> filterInfoTypeToggle;
-        private ConfigEntry<SimulateInfoType> simulateInfoTypeToggle;
-        private ConfigEntry<DebugType> debugTypeToggle;
+        private ConfigEntry<PreviewInfoType> previewInfoTypeToggle = null!;
+        private ConfigEntry<SortInfoType> sortInfoTypeToggle = null!;
+        private ConfigEntry<FilterInfoType> filterInfoTypeToggle = null!;
+        private ConfigEntry<SimulateInfoType> simulateInfoTypeToggle = null!;
+        private ConfigEntry<DebugType> debugTypeToggle = null!;
 
-        private ConfigEntry<int> moonsCatalogueSplitCount;
-        private ConfigEntry<bool> requireMatchesOnAllDungeonFlows;
+        private ConfigEntry<int> moonsCatalogueSplitCount = null!;
+        private ConfigEntry<bool> requireMatchesOnAllDungeonFlows = null!;
 
         public GeneralSettingsConfig(ConfigFile newConfigFile, string newCategory, int newSortingPriority) : base(newConfigFile, newCategory, newSortingPriority) { }
 
@@ -113,20 +113,20 @@ namespace LethalLevelLoader.Tools
 
     public class ExtendedDungeonConfig : ConfigTemplate
     {
-        public ConfigEntry<bool> enableContentConfiguration;
+        public ConfigEntry<bool> enableContentConfiguration = null!;
 
-        public ConfigEntry<string> manualLevelNames;
-        public ConfigEntry<string> manualModNames;
+        public ConfigEntry<string>? manualLevelNames;
+        public ConfigEntry<string>? manualModNames;
 
-        public ConfigEntry<bool> enableDynamicDungeonSizeRestriction;
-        public ConfigEntry<float> minimumDungeonSizeMultiplier;
-        public ConfigEntry<float> maximumDungeonSizeMultiplier;
-        public ConfigEntry<float> restrictDungeonSizeScaler;
+        public ConfigEntry<bool>? enableDynamicDungeonSizeRestriction;
+        public ConfigEntry<float>? minimumDungeonSizeMultiplier;
+        public ConfigEntry<float>? maximumDungeonSizeMultiplier;
+        public ConfigEntry<float>? restrictDungeonSizeScaler;
 
-        public ConfigEntry<string> dynamicLevelTags;
-        public ConfigEntry<string> dynamicRoutePrices;
+        public ConfigEntry<string>? dynamicLevelTags;
+        public ConfigEntry<string>? dynamicRoutePrices;
 
-        public ConfigEntry<bool> disabledWarning;
+        public ConfigEntry<bool>? disabledWarning;
 
         public ExtendedDungeonConfig(ConfigFile newConfigFile, string newCategory, int sortingPriority) : base(newConfigFile, newCategory, sortingPriority) { }
 
@@ -194,33 +194,33 @@ namespace LethalLevelLoader.Tools
     public class ExtendedLevelConfig : ConfigTemplate
     {
         //General
-        public ConfigEntry<bool> enableContentConfiguration;
+        public ConfigEntry<bool> enableContentConfiguration = null!;
 
-        public ConfigEntry<int> routePrice;
-        public ConfigEntry<float> daySpeedMultiplier;
-        public ConfigEntry<bool> doesPlanetHaveTime;
-        public ConfigEntry<bool> isLevelHidden;
-        public ConfigEntry<bool> isLevelRegistered;
+        public ConfigEntry<int>? routePrice;
+        public ConfigEntry<float>? daySpeedMultiplier;
+        public ConfigEntry<bool>? doesPlanetHaveTime;
+        public ConfigEntry<bool>? isLevelHidden;
+        public ConfigEntry<bool>? isLevelRegistered;
 
         //Scrap
-        public ConfigEntry<int> minScrapItemSpawns;
-        public ConfigEntry<int> maxScrapItemSpawns;
+        public ConfigEntry<int>? minScrapItemSpawns;
+        public ConfigEntry<int>? maxScrapItemSpawns;
 
-        public ConfigEntry<int> minTotalScrapValue;
-        public ConfigEntry<int> maxTotalScrapValue;
+        public ConfigEntry<int>? minTotalScrapValue;
+        public ConfigEntry<int>? maxTotalScrapValue;
 
-        public ConfigEntry<string> scrapOverrides;
+        public ConfigEntry<string>? scrapOverrides;
 
         //Enemies
-        public ConfigEntry<int> maxInsideEnemyPowerCount;
-        public ConfigEntry<int> maxOutsideDaytimeEnemyPowerCount;
-        public ConfigEntry<int> maxOutsideNighttimeEnemyPowerCount;
+        public ConfigEntry<int>? maxInsideEnemyPowerCount;
+        public ConfigEntry<int>? maxOutsideDaytimeEnemyPowerCount;
+        public ConfigEntry<int>? maxOutsideNighttimeEnemyPowerCount;
 
-        public ConfigEntry<string> insideEnemiesOverrides;
-        public ConfigEntry<string> outsideDaytimeEnemiesOverrides;
-        public ConfigEntry<string> outsideNighttimeEnemiesOverrides;
+        public ConfigEntry<string>? insideEnemiesOverrides;
+        public ConfigEntry<string>? outsideDaytimeEnemiesOverrides;
+        public ConfigEntry<string>? outsideNighttimeEnemiesOverrides;
 
-        public ConfigEntry<bool> disabledWarning;
+        public ConfigEntry<bool>? disabledWarning;
 
         public ExtendedLevelConfig(ConfigFile newConfigFile, string newCategory, int sortingPriority) : base(newConfigFile, newCategory, sortingPriority) { }
 

--- a/LethalLevelLoader/Tools/ContentExtractor.cs
+++ b/LethalLevelLoader/Tools/ContentExtractor.cs
@@ -39,17 +39,16 @@ namespace LethalLevelLoader
         {
             if (Plugin.IsSetupComplete == false)
             {
-                if (startOfRound != null)
-                {
-                    foreach (IndoorMapType indoorFlowType in roundManager.dungeonFlowTypes)
-                        TryAddReference(OriginalContent.DungeonFlows, indoorFlowType.dungeonFlow);
+                
+                foreach (IndoorMapType indoorFlowType in roundManager.dungeonFlowTypes)
+                    TryAddReference(OriginalContent.DungeonFlows, indoorFlowType.dungeonFlow);
 
-                    foreach (SelectableLevel selectableLevel in startOfRound.levels)
-                        ExtractSelectableLevelReferences(selectableLevel);
+                foreach (SelectableLevel selectableLevel in startOfRound.levels)
+                    ExtractSelectableLevelReferences(selectableLevel);
 
-                    foreach (IndoorMapType indoorFlowType in roundManager.dungeonFlowTypes)
-                        ExtractDungeonFlowReferences(indoorFlowType.dungeonFlow);
-                }
+                foreach (IndoorMapType indoorFlowType in roundManager.dungeonFlowTypes)
+                    ExtractDungeonFlowReferences(indoorFlowType.dungeonFlow);
+                
                 if (TerminalManager.Terminal.currentNode != null)
                     TryAddReference(OriginalContent.TerminalNodes, TerminalManager.Terminal.currentNode);
 

--- a/LethalLevelLoader/Tools/ContentRestorer.cs
+++ b/LethalLevelLoader/Tools/ContentRestorer.cs
@@ -125,8 +125,8 @@ namespace LethalLevelLoader.Tools
             AudioMixerGroup targetMixerGroup = audioSource.outputAudioMixerGroup;
             AudioMixer targetMixer = audioSource.outputAudioMixerGroup.audioMixer;
 
-            AudioMixerGroup restoredMixerGroup = null;
-            AudioMixer restoredMixer = null;
+            AudioMixerGroup? restoredMixerGroup = null;
+            AudioMixer? restoredMixer = null;
 
             foreach (AudioMixer vanillaMixer in OriginalContent.AudioMixers)
                 if (targetMixer.name == vanillaMixer.name)

--- a/LethalLevelLoader/Tools/HookHelper.cs
+++ b/LethalLevelLoader/Tools/HookHelper.cs
@@ -10,13 +10,13 @@ using System.Threading.Tasks;
 internal static class HookHelper
 {
     public static MethodInfo methodof(Delegate method) => method.Method;
-    public static MethodInfo EzGetMethod(Type type, string name, Type[] parameters = null)
+    public static MethodInfo EzGetMethod(Type type, string name, Type[]? parameters = null)
     {
         BindingFlags query = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
         if (parameters == null) return type.GetMethod(name, query);
         return type.GetMethod(name, query, null, parameters, null);
     }
-    public static MethodInfo EzGetMethod<T>(string name, Type[] parameters = null) => EzGetMethod(typeof(T), name, parameters);
+    public static MethodInfo EzGetMethod<T>(string name, Type[]? parameters = null) => EzGetMethod(typeof(T), name, parameters);
     
     public class DisposableHookCollection
     {
@@ -36,11 +36,11 @@ internal static class HookHelper
             }
             ilHooks.Clear();
         }
-        public void ILHook<T>(string methodName, ILContext.Manipulator to, Type[] parameters = null)
+        public void ILHook<T>(string methodName, ILContext.Manipulator to, Type[]? parameters = null)
         {
             ilHooks.Add(new(EzGetMethod<T>(methodName, parameters), to));
         }
-        public void Hook<T>(string methodName, Delegate to, Type[] parameters = null)
+        public void Hook<T>(string methodName, Delegate to, Type[]? parameters = null)
         {
             hooks.Add(new(EzGetMethod<T>(methodName, parameters), to));
         }


### PR DESCRIPTION
Enables the Nullable feature of C# in csproj to help better deal with null values.

```xml
<Nullable>enable</Nullable>
```

Basically, this will make you specify if your variable types are nullable or not.

For example, you'll need to write `string? something;` instead of `string something;` if the `something` variable might be null, so the IDE knows to warn you when you try to access the variable and it isn't sure it's not null (This will help catch Null Reference Exceptions much easier). See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/nullable-value-types

You can use `string something = null!;` instead if you know this won't be null when it matters or whatever. See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/null-forgiving

I also tried to resolve quite a bit of stuff (not everything yet, will continue later), by quickly looking how each variable with a nullability warning was used, and marked them as nullable if there code that checked if they were null in other places than just some init methods. A lot of what I did might not be perfect, but it's a lot better than nothing.

There are still a few nullable warnings that I didn't analyze enough (of the ones I did go through), since I marked a thing as nullable because from the code it seemed like there were a lot of null checks for it, but then it's used in some patches without checking for null. So these need to be reviewed a little more closely, but I'm done for today with this.

Also related:
For when(/if) you make more `TryGet` methods that give back a nullable variable type that is known to be null when return value is false and not null when return value is true, there is an attribute for marking that, e.g. `[NotNullWhen(returnValue: true)] out ExtendedDungeonFlow? returnExtendedDungeonFlow`: https://stackoverflow.com/a/57627724