### PR TITLE
Add embedded debug symbols (& fix inconsisent indentation in csproj)

### DIFF
--- a/LethalLevelLoader/LethalLevelLoader.csproj
+++ b/LethalLevelLoader/LethalLevelLoader.csproj
@@ -1,51 +1,62 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-      <TargetFramework>netstandard2.1</TargetFramework>
-      <AssemblyName>LethalLevelLoader</AssemblyName>
-      <Description>A Custom API to support the manual and dynamic integration of custom levels and dungeons in Lethal Company.</Description>
-      <Version>1.1.0</Version>
-      <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-      <LangVersion>preview</LangVersion>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>netstandard2.1</TargetFramework>
+        <AssemblyName>LethalLevelLoader</AssemblyName>
+        <Description>A Custom API to support the manual and dynamic integration of custom levels and dungeons in Lethal Company.</Description>
+        <Version>1.1.0</Version>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <LangVersion>preview</LangVersion>
+    </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
-      <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
-  </ItemGroup>
+    <!-- Embed Debug Symbols for Easier Debugging -->
+    <PropertyGroup>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>embedded</DebugType>
+        <!--
+        Trim the project path to prevent players from potentially
+        viewing Private Information in stack traces.
+        -->
+        <PathMap>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=./</PathMap>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="VanillaContentTags\Enemies.csv" />
-    <None Remove="VanillaContentTags\Items.csv" />
-    <None Remove="VanillaContentTags\SelectableLevels.csv" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="VanillaContentTags\Enemies.csv" />
-    <EmbeddedResource Include="VanillaContentTags\Items.csv" />
-    <EmbeddedResource Include="VanillaContentTags\SelectableLevels.csv" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Remove="VanillaContentTags\Enemies.csv" />
+        <None Remove="VanillaContentTags\Items.csv" />
+        <None Remove="VanillaContentTags\SelectableLevels.csv" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="BepInEx.Core" Version="5.4.21" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="VanillaContentTags\Enemies.csv" />
+        <EmbeddedResource Include="VanillaContentTags\Items.csv" />
+        <EmbeddedResource Include="VanillaContentTags\SelectableLevels.csv" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Evaisa.LethalLib" Version="0.16.0" />
-    <PackageReference Include="MaxWasUnavailable.LethalModDataLib" Version="1.2.2" />
-    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="55.0.0-beta.0-ngd.0" Publicize="true" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="BepInEx.Core" Version="5.4.21" />
+    </ItemGroup>
 
-  <Target Name="NetcodePatch" AfterTargets="PostBuildEvent">
-  <Exec Command="netcode-patch &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies-> '&quot;%(Identity)&quot;', ' ')" />
-  </Target>
+    <ItemGroup>
+        <PackageReference Include="Evaisa.LethalLib" Version="0.16.0" />
+        <PackageReference Include="MaxWasUnavailable.LethalModDataLib" Version="1.2.2" />
+        <PackageReference Include="LethalCompany.GameLibs.Steam" Version="55.0.0-beta.0-ngd.0" Publicize="true" />
+    </ItemGroup>
 
-  <Target Name="CopyToDebugProfile" AfterTargets="NetcodePatch" Condition="'$(Configuration)' == 'Debug'">
-    <Message Importance="high" Text="Copying To Lethal Company Dir" />
-    <Copy SourceFiles="$(TargetDir)LethalLevelLoader.dll" DestinationFolder="C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\BepInEx\plugins\LethalLevelLoader" />
-  </Target>
-  
+    <Target Name="NetcodePatch" AfterTargets="PostBuildEvent">
+        <Exec Command="netcode-patch &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies-> '&quot;%(Identity)&quot;', ' ')" />
+    </Target>
+
+    <Target Name="CopyToDebugProfile" AfterTargets="NetcodePatch" Condition="'$(Configuration)' == 'Debug'">
+        <Message Importance="high" Text="Copying To Lethal Company Dir" />
+        <Copy SourceFiles="$(TargetDir)LethalLevelLoader.dll" DestinationFolder="C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\BepInEx\plugins\LethalLevelLoader" />
+    </Target>
+
 </Project>


### PR DESCRIPTION
Adds embedded debug symbols, so errors give the line number for the file where error happened, instead of an IL offset.

Example:
```
[Error  : Unity Log] NotImplementedException: The method or operation is not implemented.
Stack trace:
LethalLevelLoader.Plugin.Awake () (at ./Plugin.cs:48)
UnityEngine.GameObject:AddComponent(Type)
BepInEx.Bootstrap.Chainloader:Start()
UnityEngine.InputSystem.InputSystem:.cctor()
```

And uhh I also fixed the inconsistent indentation in the csproj file while I was at it, so I hope that's fine.