### PR TITLE
Typo/Grammar Fixes

### DIFF
--- a/LethalLevelLoader/General/Content.cs
+++ b/LethalLevelLoader/General/Content.cs
@@ -55,12 +55,6 @@ namespace LethalLevelLoader
             }
         }
 
-        [Obsolete("Use PatchedContent.SelectableLevels instead.")] // probably used by no mod, but this is public so we should be careful
-        public static List<SelectableLevel> SeletectableLevels
-        {
-            get { return (SelectableLevels); }
-        }
-
         public static List<SelectableLevel> MoonsCatalogue
         {
             get

--- a/LethalLevelLoader/General/Content.cs
+++ b/LethalLevelLoader/General/Content.cs
@@ -43,7 +43,8 @@ namespace LethalLevelLoader
             }
         }
 
-        public static List<SelectableLevel> SeletectableLevels
+
+        public static List<SelectableLevel> SelectableLevels
         {
             get
             {
@@ -52,7 +53,12 @@ namespace LethalLevelLoader
                     list.Add(level.SelectableLevel);
                 return (list);
             }
-       
+        }
+
+        [Obsolete("Use PatchedContent.SelectableLevels instead.")] // probably used by no mod, but this is public so we should be careful
+        public static List<SelectableLevel> SeletectableLevels
+        {
+            get { return (SelectableLevels); }
         }
 
         public static List<SelectableLevel> MoonsCatalogue

--- a/LethalLevelLoader/General/EventPatches.cs
+++ b/LethalLevelLoader/General/EventPatches.cs
@@ -14,7 +14,7 @@ using UnityEngine.SceneManagement;
 namespace LethalLevelLoader
 {
     //This class is dedicated to the patches needed to collect data sent to events inside the current ExtendedLevel and ExtendedDungeonFlow.
-    //They are seperated for organisation purposes and to enforce that all of these patches should only be reading information and sending it off
+    //They are separated for organisation purposes and to enforce that all of these patches should only be reading information and sending it off
     //Nothing in this class should modify the game in any way.
     internal class EventPatches
     {

--- a/LethalLevelLoader/General/Patches.cs
+++ b/LethalLevelLoader/General/Patches.cs
@@ -191,7 +191,7 @@ namespace LethalLevelLoader
                 //Terminal Specific Reference Setup
                 TerminalManager.CacheTerminalReferences();
 
-                LevelManager.InitalizeShipAnimatorOverrideController();
+                LevelManager.InitializeShipAnimatorOverrideController();
 
                 DungeonLoader.defaultKeyPrefab = RoundManager.keyPrefab;
                 LevelLoader.defaultQuicksandPrefab = RoundManager.quicksandPrefab;
@@ -627,7 +627,7 @@ namespace LethalLevelLoader
                 }
         }
 
-        static List<SpawnableMapObject> tempoarySpawnableMapObjectList = new List<SpawnableMapObject>();
+        static List<SpawnableMapObject> temporarySpawnableMapObjectList = new List<SpawnableMapObject>();
 
         [HarmonyPriority(harmonyPriority)]
         [HarmonyPatch(typeof(RoundManager), "SpawnMapObjects")]
@@ -638,7 +638,7 @@ namespace LethalLevelLoader
             foreach (SpawnableMapObject newRandomMapObject in DungeonManager.CurrentExtendedDungeonFlow.SpawnableMapObjects)
             {
                 spawnableMapObjects.Add(newRandomMapObject);
-                tempoarySpawnableMapObjectList.Add(newRandomMapObject);
+                temporarySpawnableMapObjectList.Add(newRandomMapObject);
             }
             LevelManager.CurrentExtendedLevel.SelectableLevel.spawnableMapObjects = spawnableMapObjects.ToArray();
         }
@@ -649,10 +649,10 @@ namespace LethalLevelLoader
         internal static void RoundManagerSpawnMapObjects_Postfix()
         {
             List<SpawnableMapObject> spawnableMapObjects = new List<SpawnableMapObject>(LevelManager.CurrentExtendedLevel.SelectableLevel.spawnableMapObjects);
-            foreach (SpawnableMapObject spawnableMapObject in tempoarySpawnableMapObjectList)
+            foreach (SpawnableMapObject spawnableMapObject in temporarySpawnableMapObjectList)
                 spawnableMapObjects.Remove(spawnableMapObject);
             LevelManager.CurrentExtendedLevel.SelectableLevel.spawnableMapObjects = spawnableMapObjects.ToArray();
-            tempoarySpawnableMapObjectList.Clear();
+            temporarySpawnableMapObjectList.Clear();
         }
 
         internal static GameObject previousHit;

--- a/LethalLevelLoader/General/Patches.cs
+++ b/LethalLevelLoader/General/Patches.cs
@@ -88,7 +88,7 @@ namespace LethalLevelLoader
 
             if (AssetBundleLoader.CurrentLoadingStatus == AssetBundleLoader.LoadingStatus.Loading)
             {
-                DebugHelper.LogWarning("SceneManager has attempted to load " + sceneName + " Scene before AssetBundles have finished loading. Pausing request until LethalLeveLoader is ready to proceed.", DebugType.User);
+                DebugHelper.LogWarning("SceneManager has attempted to load " + sceneName + " Scene before AssetBundles have finished loading. Pausing request until LethalLevelLoader is ready to proceed.", DebugType.User);
                 delayedSceneLoadingName = sceneName;
                 AssetBundleLoader.onBundlesFinishedLoading -= LoadMainMenu;
                 AssetBundleLoader.onBundlesFinishedLoading += LoadMainMenu;
@@ -179,7 +179,7 @@ namespace LethalLevelLoader
             if (GameNetworkManager.Instance.GetComponent<NetworkManager>().IsServer)
                 GameObject.Instantiate(LethalLevelLoaderNetworkManager.networkingManagerPrefab).GetComponent<NetworkObject>().Spawn(destroyWithScene: false);
 
-            //Add the facility's firstTimeDungeonAudio additionally to RoundManager's list to fix a basegame bug.
+            //Add the facility's firstTimeDungeonAudio additionally to RoundManager's list to fix a base game bug.
             RoundManager.firstTimeDungeonAudios = RoundManager.firstTimeDungeonAudios.ToList().AddItem(RoundManager.firstTimeDungeonAudios[0]).ToArray();
             DebugStopwatch.StartStopWatch("Fix AudioSource Settings");
             //Disable Spatialization In All AudioSources To Fix Log Spam Bug.
@@ -203,7 +203,7 @@ namespace LethalLevelLoader
                 AssetBundleLoader.CreateVanillaExtendedItems();
                 AssetBundleLoader.CreateVanillaExtendedEnemyTypes();
 
-                DebugStopwatch.StartStopWatch("Initalize Custom ExtendedContent");
+                DebugStopwatch.StartStopWatch("Initialize Custom ExtendedContent"); // this is not used
                 //Initialize ExtendedContent Objects For Custom Content.
                 AssetBundleLoader.InitializeBundles();
 
@@ -245,7 +245,7 @@ namespace LethalLevelLoader
                 //Apply ContentTags To Vanilla ExtendedContent Objects.
                 ContentTagParser.ApplyVanillaContentTags();
 
-                //Iterate Through All ExtendedMod Objects And Merge Any Reoccuring ContentTagName In The Same ExtendedMod.
+                //Iterate Through All ExtendedMod Objects And Merge Any Reoccurring ContentTagName In The Same ExtendedMod.
                 ContentTagManager.MergeAllExtendedModTags();
 
                 //Populate Information About All Current ContentTag's Used In ExtendedContent For Developer Use.
@@ -258,17 +258,17 @@ namespace LethalLevelLoader
             }
 
             DebugStopwatch.StartStopWatch("Bind Configs");
-            //Bind User Configation Information.
+            //Bind User Configuration Information.
             ConfigLoader.BindConfigs();
 
-            DebugStopwatch.StartStopWatch("Patch Basegame Lists");
-            //Patch The Basegame References To SelectableLevel's To Include Enabled Custom SelectableLevels.
+            DebugStopwatch.StartStopWatch("Patch Base game Lists");
+            //Patch The Base game References To SelectableLevel's To Include Enabled Custom SelectableLevels.
             LevelManager.PatchVanillaLevelLists();
 
-            //Patch The Basegame References To DungeonFlows's To Include Enabled Custom DungeonFlows.
+            //Patch The Base game References To DungeonFlows's To Include Enabled Custom DungeonFlows.
             DungeonManager.PatchVanillaDungeonLists();
 
-            //Patch The Basegame References To EnemyTypes's To Include Enabled Custom EnemyTypes.
+            //Patch The Base game References To EnemyTypes's To Include Enabled Custom EnemyTypes.
             EnemyManager.UpdateEnemyIDs(); //Might only need to do once?
 
             foreach (ExtendedEnemyType extendedEnemyType in PatchedContent.CustomExtendedEnemyTypes)
@@ -299,7 +299,7 @@ namespace LethalLevelLoader
                 foreach (CompatibleNoun routeNode in TerminalManager.routeKeyword.compatibleNouns)
                     TerminalManager.AddTerminalNodeEventListener(routeNode.result, TerminalManager.OnBeforeRouteNodeLoaded, TerminalManager.LoadNodeActionType.Before);
 
-                //Create Terminal Data For Custom StoryLog's And Patch Basegame References To StoryLog's To Include Custom StoryLogs.
+                //Create Terminal Data For Custom StoryLog's And Patch Base game References To StoryLog's To Include Custom StoryLogs.
                 TerminalManager.CreateTerminalDataForAllExtendedStoryLogs();
 
                 TerminalManager.AddTerminalNodeEventListener(TerminalManager.moonsKeyword.specialKeywordResult, TerminalManager.RefreshMoonsCataloguePage, TerminalManager.LoadNodeActionType.After);
@@ -314,14 +314,14 @@ namespace LethalLevelLoader
                 LevelManager.invalidSaveLevelID = -1;
             }*/
 
-            DebugStopwatch.StartStopWatch("Initalize Save");
+            DebugStopwatch.StartStopWatch("Initialize Save");
 
             if (LethalLevelLoaderNetworkManager.networkManager.IsServer)
             {
                 SaveManager.InitializeSave();
             }
 
-            DebugStopwatch.StopStopWatch("Initalize Save");
+            DebugStopwatch.StopStopWatch("Initialize Save");
             if (Plugin.IsSetupComplete == false)
             {
                 AssetBundleLoader.CreateVanillaExtendedWeatherEffects(StartOfRound, TimeOfDay);
@@ -363,7 +363,7 @@ namespace LethalLevelLoader
             if (LethalLevelLoaderNetworkManager.networkManager.IsServer == false)
                 return (true);
 
-            //Because Level ID's can change between modpack adjustments and such, we save the name of the level instead and find and load that up instead of the saved ID the basegame uses.
+            //Because Level ID's can change between modpack adjustments and such, we save the name of the level instead and find and load that up instead of the saved ID the base game uses.
             if (hasInitiallyChangedLevel == false && !string.IsNullOrEmpty(SaveManager.currentSaveFile.CurrentLevelName))
                 foreach (ExtendedLevel extendedLevel in PatchedContent.ExtendedLevels)
                     if (extendedLevel.SelectableLevel.name == SaveManager.currentSaveFile.CurrentLevelName)
@@ -533,7 +533,7 @@ namespace LethalLevelLoader
                 DebugHelper.LogError("Critical Failure! DungeonGenerator DungeonFlow Is Null!", DebugType.User);
         }
 
-        //Basegame has a bug where it stops listening before it gets the Complete call, so this is just a fixed version of the basegame function.
+        //Base game has a bug where it stops listening before it gets the Complete call, so this is just a fixed version of the base game function.
         [HarmonyPriority(harmonyPriority)]
         [HarmonyPatch(typeof(RoundManager), "Generator_OnGenerationStatusChanged")]
         [HarmonyPrefix]
@@ -694,7 +694,7 @@ namespace LethalLevelLoader
             */
         }
 
-        //DunGen Optimisation Patches (Credit To LadyRaphtalia, Author Of Scarlet Devil Mansion)
+        //DunGen Optimization Patches (Credit To LadyRaphtalia, Author Of Scarlet Devil Mansion)
         [HarmonyPriority(harmonyPriority)]
         [HarmonyPatch(typeof(DoorwayPairFinder), "GetDoorwayPairs")]
         [HarmonyPrefix]

--- a/LethalLevelLoader/General/SafetyPatches.cs
+++ b/LethalLevelLoader/General/SafetyPatches.cs
@@ -26,7 +26,7 @@ namespace LethalLevelLoader
             }*/
         }
 
-        static List<SpawnableMapObject> tempoarySpawnableMapObjectList = new List<SpawnableMapObject>();
+        static List<SpawnableMapObject> temporarySpawnableMapObjectList = new List<SpawnableMapObject>();
 
         [HarmonyPriority(harmonyPriority)]
         [HarmonyPatch(typeof(RoundManager), "SpawnMapObjects")]
@@ -67,7 +67,7 @@ namespace LethalLevelLoader
                 spawnableMapObject.prefabToSpawn = orphanedMapObject;
                 spawnableMapObject.numberToSpawn = curve;
                 spawnableMapObjects.Add(spawnableMapObject);
-                tempoarySpawnableMapObjectList.Add(spawnableMapObject);
+                temporarySpawnableMapObjectList.Add(spawnableMapObject);
             }
             LevelManager.CurrentExtendedLevel.SelectableLevel.spawnableMapObjects = spawnableMapObjects.ToArray();
 
@@ -80,10 +80,10 @@ namespace LethalLevelLoader
         internal static void RoundManagerSpawnMapObjects_Postfix()
         {
             List<SpawnableMapObject> spawnableMapObjects = new List<SpawnableMapObject>(LevelManager.CurrentExtendedLevel.SelectableLevel.spawnableMapObjects);
-            foreach (SpawnableMapObject spawnableMapObject in tempoarySpawnableMapObjectList)
+            foreach (SpawnableMapObject spawnableMapObject in temporarySpawnableMapObjectList)
                 spawnableMapObjects.Remove(spawnableMapObject);
             LevelManager.CurrentExtendedLevel.SelectableLevel.spawnableMapObjects = spawnableMapObjects.ToArray();
-            tempoarySpawnableMapObjectList.Clear();
+            temporarySpawnableMapObjectList.Clear();
         }
 
 

--- a/LethalLevelLoader/General/SafetyPatches.cs
+++ b/LethalLevelLoader/General/SafetyPatches.cs
@@ -120,13 +120,13 @@ namespace LethalLevelLoader
             {
                 if ((int)__instance.currentWeatherVariable >= (int)__instance.currentWeatherVariable2)
                 {
-                    DebugHelper.LogError("TimeOfDay Foggy CurrentWeatherVariable (Int) Was Equal Or Higher Than CurrentWeatherVariable2 (Int). Resetting For Safetey!", DebugType.User);
+                    DebugHelper.LogError("TimeOfDay Foggy CurrentWeatherVariable (Int) Was Equal Or Higher Than CurrentWeatherVariable2 (Int). Resetting For Safety!", DebugType.User);
                     __instance.currentWeatherVariable = 3f;
                     __instance.currentWeatherVariable2 = 10f;
                 }
                 else if ((int)__instance.currentWeatherVariable <= 0 || (int)__instance.currentWeatherVariable2 <= 0)
                 {
-                    DebugHelper.LogError("TimeOfDay Foggy CurrentWeatherVariable (Int) And/Or CurrentWeatherVariable2 (Int) Were 0. Resetting For Safetey!", DebugType.User);
+                    DebugHelper.LogError("TimeOfDay Foggy CurrentWeatherVariable (Int) And/Or CurrentWeatherVariable2 (Int) Were 0. Resetting For Safety!", DebugType.User);
                     __instance.currentWeatherVariable = 3f;
                     __instance.currentWeatherVariable2 = 10f;
                 }

--- a/LethalLevelLoader/Loaders/DungeonLoader.cs
+++ b/LethalLevelLoader/Loaders/DungeonLoader.cs
@@ -58,7 +58,7 @@ namespace LethalLevelLoader
                     calculatedMultiplier = Mathf.Lerp(calculatedMultiplier, extendedDungeonFlow.DynamicDungeonSizeMinMax.y, extendedDungeonFlow.DynamicDungeonSizeLerpRate); //This is how vanilla does it.
                 else if (calculatedMultiplier < extendedDungeonFlow.DynamicDungeonSizeMinMax.x)
                     calculatedMultiplier = Mathf.Lerp(calculatedMultiplier, extendedDungeonFlow.DynamicDungeonSizeMinMax.x, extendedDungeonFlow.DynamicDungeonSizeLerpRate);//This is how vanilla does it.
-                DebugHelper.Log("Current ExtendedLevel: " + LevelManager.CurrentExtendedLevel.NumberlessPlanetName + " ExtendedLevel DungeonSize Is: " + LevelManager.CurrentExtendedLevel.SelectableLevel.factorySizeMultiplier + " | Overrriding DungeonSize To: " + calculatedMultiplier, DebugType.User);
+                DebugHelper.Log("Current ExtendedLevel: " + LevelManager.CurrentExtendedLevel.NumberlessPlanetName + " ExtendedLevel DungeonSize Is: " + LevelManager.CurrentExtendedLevel.SelectableLevel.factorySizeMultiplier + " | Overriding DungeonSize To: " + calculatedMultiplier, DebugType.User);
             }
             else
                 DebugHelper.Log("CurrentLevel: " + LevelManager.CurrentExtendedLevel.NumberlessPlanetName + " DungeonSize Is: " + LevelManager.CurrentExtendedLevel.SelectableLevel.factorySizeMultiplier + " | Leaving DungeonSize As: " + calculatedMultiplier, DebugType.User);
@@ -119,7 +119,7 @@ namespace LethalLevelLoader
                 foreach (GlobalPropSettings globalPropSettings in dungeonGenerator.DungeonFlow.GlobalProps)
                     if (globalPropSettings.ID == 1231)
                     {
-                        debugString += "Found Fire Escape GlobalProp: (ID: 1231), Modifying Spawnrate Count From (" + globalPropSettings.Count.Min + "," + globalPropSettings.Count.Max + ") To (" + (entranceTeleports.Count - 1) + "," + (entranceTeleports.Count - 1) + ")" + "\n";
+                        debugString += "Found Fire Escape GlobalProp: (ID: 1231), Modifying Spawn rate Count From (" + globalPropSettings.Count.Min + "," + globalPropSettings.Count.Max + ") To (" + (entranceTeleports.Count - 1) + "," + (entranceTeleports.Count - 1) + ")" + "\n";
                         globalPropSettings.Count = new IntRange(entranceTeleports.Count - 1, entranceTeleports.Count - 1); //-1 Because .Count includes the Main Entrance.
                         break;
                     }

--- a/LethalLevelLoader/Loaders/DungeonLoader.cs
+++ b/LethalLevelLoader/Loaders/DungeonLoader.cs
@@ -74,10 +74,6 @@ namespace LethalLevelLoader
             return 1f;
         }
 
-        [System.Obsolete("Use DungeonLoader.CalculateDungeonMultiplier instead.")]
-        public static float CalculateDungeonMutliplier(ExtendedLevel extendedLevel, ExtendedDungeonFlow extendedDungeonFlow) =>
-            CalculateDungeonMultiplier(extendedLevel, extendedDungeonFlow);
-
         internal static void PatchDungeonSize(DungeonGenerator dungeonGenerator, ExtendedLevel extendedLevel, ExtendedDungeonFlow extendedDungeonFlow)
         {
             /*if (extendedDungeonFlow.enableDynamicDungeonSizeRestriction == true)

--- a/LethalLevelLoader/Loaders/DungeonLoader.cs
+++ b/LethalLevelLoader/Loaders/DungeonLoader.cs
@@ -51,7 +51,7 @@ namespace LethalLevelLoader
         {
             ExtendedDungeonFlow extendedDungeonFlow = DungeonManager.CurrentExtendedDungeonFlow;
             ExtendedLevel extendedLevel = LevelManager.CurrentExtendedLevel;
-            float calculatedMultiplier = CalculateDungeonMutliplier(LevelManager.CurrentExtendedLevel, DungeonManager.CurrentExtendedDungeonFlow);
+            float calculatedMultiplier = CalculateDungeonMultiplier(LevelManager.CurrentExtendedLevel, DungeonManager.CurrentExtendedDungeonFlow);
             if (DungeonManager.CurrentExtendedDungeonFlow != null && DungeonManager.CurrentExtendedDungeonFlow.IsDynamicDungeonSizeRestrictionEnabled == true)
             {
                 if (calculatedMultiplier > extendedDungeonFlow.DynamicDungeonSizeMinMax.y)
@@ -65,15 +65,18 @@ namespace LethalLevelLoader
             return (calculatedMultiplier);
         }
 
-        public static float CalculateDungeonMutliplier(ExtendedLevel extendedLevel, ExtendedDungeonFlow extendedDungeonFlow)
+        public static float CalculateDungeonMultiplier(ExtendedLevel extendedLevel, ExtendedDungeonFlow extendedDungeonFlow)
         {
             foreach (IndoorMapType indoorMapType in RoundManager.Instance.dungeonFlowTypes)
                 if (indoorMapType.dungeonFlow == extendedDungeonFlow.DungeonFlow)
                     return (extendedLevel.SelectableLevel.factorySizeMultiplier / indoorMapType.MapTileSize * RoundManager.Instance.mapSizeMultiplier);
-            
-            return 1f;
 
+            return 1f;
         }
+
+        [System.Obsolete("Use DungeonLoader.CalculateDungeonMultiplier instead.")]
+        public static float CalculateDungeonMutliplier(ExtendedLevel extendedLevel, ExtendedDungeonFlow extendedDungeonFlow) =>
+            CalculateDungeonMultiplier(extendedLevel, extendedDungeonFlow);
 
         internal static void PatchDungeonSize(DungeonGenerator dungeonGenerator, ExtendedLevel extendedLevel, ExtendedDungeonFlow extendedDungeonFlow)
         {

--- a/LethalLevelLoader/Patches/LevelManager.cs
+++ b/LethalLevelLoader/Patches/LevelManager.cs
@@ -61,7 +61,7 @@ namespace LethalLevelLoader
 
         internal static void PatchVanillaLevelLists()
         {
-            Patches.StartOfRound.levels = PatchedContent.SeletectableLevels.ToArray();
+            Patches.StartOfRound.levels = PatchedContent.SelectableLevels.ToArray();
             TerminalManager.Terminal.moonsCatalogueList = PatchedContent.MoonsCatalogue.ToArray();
         }
 

--- a/LethalLevelLoader/Patches/LevelManager.cs
+++ b/LethalLevelLoader/Patches/LevelManager.cs
@@ -65,7 +65,7 @@ namespace LethalLevelLoader
             TerminalManager.Terminal.moonsCatalogueList = PatchedContent.MoonsCatalogue.ToArray();
         }
 
-        internal static void InitalizeShipAnimatorOverrideController()
+        internal static void InitializeShipAnimatorOverrideController()
         {
             Animator shipAnimator = Patches.StartOfRound.shipAnimator;
 

--- a/LethalLevelLoader/Patches/TerminalManager.cs
+++ b/LethalLevelLoader/Patches/TerminalManager.cs
@@ -323,7 +323,7 @@ namespace LethalLevelLoader
             return (overviewText + GetMoonCatalogDisplayListings() + "\r\n");
         }
 
-        //This is some abslolute super arbitary wizardry to replicate basegame >moons command
+        //This is some absolute super arbitrary wizardry to replicate base game >moons command
         public static string GetMoonCatalogDisplayListings()
         {
             string returnString = string.Empty;
@@ -676,7 +676,7 @@ namespace LethalLevelLoader
                 terminalNodeInfo.displayText = infoString;
             }
 
-            //Population Into Basegame
+            //Population Into Base game
 
             terminalNodeRoute.AddCompatibleNoun(routeDenyKeyword, cancelRouteNode);
             terminalNodeRoute.AddCompatibleNoun(routeConfirmKeyword, terminalNodeRouteConfirm);
@@ -794,7 +794,7 @@ namespace LethalLevelLoader
             }
 
 
-            //Population Into Basegame
+            //Population Into Base game
 
             terminalNodeBuy.AddCompatibleNoun(routeConfirmKeyword, terminalNodeBuyConfirm);
             terminalNodeBuy.AddCompatibleNoun(routeDenyKeyword, cancelPurchaseNode);

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 
 ### **1.2.0 for Lethal Company v50 Has Released!**
 
-**LethalLevelLoader** is a custom API to support the manual and dynamic integration of custom levels and dungeons in Lethal Company. 
-Mod Developers can provide LethalLevelLoader with their custom content via code or via automatic assetbundle detection, From there LethalLevelLoader will seamlessly load it into the game.
+**LethalLevelLoader** is a custom API to support the manual and dynamic integration of custom levels and dungeons in Lethal Company.  
+Mod Developers can provide LethalLevelLoader with their custom content via code or via automatic AssetBundle detection, and from there LethalLevelLoader will seamlessly load the content into the game.
 
-This Mod is Likely To Be Incompataible with **LethalExpansion**, Due To The inherit conflicts involved in changing the same systems.
+This Mod is Likely To Be Incompatible with **LethalExpansion**, Due To The inherit conflicts involved in changing the same systems.
 
 **How To Use (Users / Players)**
 --
@@ -30,7 +30,7 @@ This Mod is Likely To Be Incompataible with **LethalExpansion**, Due To The inhe
 --
 
 
-  Please refer to the LethalLevelLoader Wiki for documentation on utalising this API for your custom content
+  Please refer to the LethalLevelLoader Wiki for documentation on utilizing this API for your custom content:
   https://github.com/IAmBatby/LethalLevelLoader/wiki
 
 **Features Currently Supported**
@@ -56,8 +56,8 @@ This Mod is Likely To Be Incompataible with **LethalExpansion**, Due To The inhe
 * **Lordfirespeed** *(Lordfirespeed provided multiple instances of Bepinex & Unity.Netcode related support during the development of this Mod.)*
 * **onionymous** *(Onionymous provided a preview build of their Networked Scene Patcher API, allowing for dynamic, networked scene injection)*
 * **Game-Icons.net** *(For the artwork used for the mod's logo)*
-**Maxwasunavailable** *(For creating LethalModDataLib and assisting me with it’s usage.)*
-**Mrov** *(For collaborating with me on initial Custom weather support related code, assisting in fixes related to the Config file and a bunch of miscellaneous assistance.)*
-**LadyRaphtalia**, **Xu Xiaolan**, **Badhamknibbs**, **Mrov**, **sfDesat**, **AboveFire**, **Autumnis The Everchanging**, **RosiePies**, **Drako** & **Audio Knight** *(For testing development on experimental 1.2.0 builds.)*
-**狐萝卜呀**, **tumbleweed**, **Corey**, **Ritskee**, **Altan**, **qxZap**, **Salamander**, **Chiseled Cactus**, **Phantom139**, **ImmaBawss**, **takeothewolf**, **zuzaratrust**, **Hackattack242**, **Mail Me Dabs**, **Kyros**, **SourceShard** & **Chupacabra** *(For playtesting and reporting bugs on experimental 1.2.0 builds.*
-**Lunxara** *For the heavy, rapid testing throughout all the experimental 1.2.0 builds.*)
+* **Maxwasunavailable** *(For creating LethalModDataLib and assisting me with it’s usage.)*
+* **Mrov** *(For collaborating with me on initial Custom weather support related code, assisting in fixes related to the Config file and a bunch of miscellaneous assistance.)*
+* **LadyRaphtalia**, **Xu Xiaolan**, **Badhamknibbs**, **Mrov**, **sfDesat**, **AboveFire**, **Autumnis The Everchanging**, **RosiePies**, **Drako** & **Audio Knight** *(For testing development on experimental 1.2.0 builds.)*
+* **狐萝卜呀**, **tumbleweed**, **Corey**, **Ritskee**, **Altan**, **qxZap**, **Salamander**, **Chiseled Cactus**, **Phantom139**, **ImmaBawss**, **takeothewolf**, **zuzaratrust**, **Hackattack242**, **Mail Me Dabs**, **Kyros**, **SourceShard** & **Chupacabra** *(For playtesting and reporting bugs on experimental 1.2.0 builds.*
+* **Lunxara** *For the heavy, rapid testing throughout all the experimental 1.2.0 builds.*)


### PR DESCRIPTION
Fixes many typos/grammar mistakes, including for public stuff in code, in which case the stuff with typos was kept but marked as obsolete and made to point the new one with the fixed name, to prevent some mod using them possibly breaking (although it's unlikely that stuff was used by any mods).