### PR TITLE
Add enum utils to not use any custom enums

### DIFF
--- a/LethalLevelLoader/LethalLevelLoader.csproj
+++ b/LethalLevelLoader/LethalLevelLoader.csproj
@@ -61,6 +61,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MegaPiggy.LCEnumUtils" Version="1.0.5" />
     <PackageReference Include="Evaisa.LethalLib" Version="0.16.0" />
     <PackageReference Include="MaxWasUnavailable.LethalModDataLib" Version="1.2.2" />
     <PackageReference Include="LethalCompany.GameLibs.Steam" Version="56.0.1-ngd.0" Publicize="true" />

--- a/LethalLevelLoader/Patches/TerminalManager.cs
+++ b/LethalLevelLoader/Patches/TerminalManager.cs
@@ -165,13 +165,13 @@ namespace LethalLevelLoader
             /*if (node != null && string.IsNullOrEmpty(node.terminalEvent) == false)
             {
                 //DebugHelper.Log("Running LLL Terminal Event: " + node.terminalEvent + "| EnumValue: " + GetTerminalEventEnum(node.terminalEvent) + " | StringValue: " + GetTerminalEventString(node.terminalEvent));
-                if (node.name.Contains("preview") && Enum.TryParse(typeof(PreviewInfoType), GetTerminalEventEnum(node.terminalEvent), out object previewEnumValue))
-                    Settings.levelPreviewInfoType = (PreviewInfoType)previewEnumValue;
-                else if (node.name.Contains("sort") && Enum.TryParse(typeof(SortInfoType), GetTerminalEventEnum(node.terminalEvent), out object sortEnumValue))
-                    Settings.levelPreviewSortType = (SortInfoType)sortEnumValue;
-                else if (node.name.Contains("filter") && Enum.TryParse(typeof(FilterInfoType), GetTerminalEventEnum(node.terminalEvent), out object filterEnumValue))
+                if (node.name.Contains("preview") && EnumUtils.TryParse<PreviewInfoType>(GetTerminalEventEnum(node.terminalEvent), out PreviewInfoType previewEnumValue))
+                    Settings.levelPreviewInfoType = previewEnumValue;
+                else if (node.name.Contains("sort") && EnumUtils.TryParse<SortInfoType>(GetTerminalEventEnum(node.terminalEvent), out SortInfoType sortEnumValue))
+                    Settings.levelPreviewSortType = sortEnumValue;
+                else if (node.name.Contains("filter") && EnumUtils.TryParse<FilterInfoType>(GetTerminalEventEnum(node.terminalEvent), out FilterInfoType filterEnumValue))
                 {
-                    Settings.levelPreviewFilterType = (FilterInfoType)filterEnumValue;
+                    Settings.levelPreviewFilterType = filterEnumValue;
                     currentTagFilter = GetTerminalEventString(node.terminalEvent);
                     DebugHelper.Log("Tag EventString: " + GetTerminalEventString(node.terminalEvent));
                 }
@@ -197,13 +197,13 @@ namespace LethalLevelLoader
         public static bool RefreshMoonsCataloguePage(ref TerminalNode currentNode, ref TerminalNode loadNode)
         {
             //DebugHelper.Log("Running LLL Terminal Event: " + node.terminalEvent + "| EnumValue: " + GetTerminalEventEnum(node.terminalEvent) + " | StringValue: " + GetTerminalEventString(node.terminalEvent));
-            if (loadNode.name.Contains("preview") && Enum.TryParse(typeof(PreviewInfoType), GetTerminalEventEnum(loadNode.terminalEvent), out object previewEnumValue))
-                Settings.levelPreviewInfoType = (PreviewInfoType)previewEnumValue;
-            else if (loadNode.name.Contains("sort") && Enum.TryParse(typeof(SortInfoType), GetTerminalEventEnum(loadNode.terminalEvent), out object sortEnumValue))
-                Settings.levelPreviewSortType = (SortInfoType)sortEnumValue;
-            else if (loadNode.name.Contains("filter") && Enum.TryParse(typeof(FilterInfoType), GetTerminalEventEnum(loadNode.terminalEvent), out object filterEnumValue))
+            if (loadNode.name.Contains("preview") && EnumUtils.TryParse<PreviewInfoType>(GetTerminalEventEnum(loadNode.terminalEvent), out PreviewInfoType previewEnumValue))
+                Settings.levelPreviewInfoType = previewEnumValue;
+            else if (loadNode.name.Contains("sort") && EnumUtils.TryParse<SortInfoType>(GetTerminalEventEnum(loadNode.terminalEvent), out SortInfoType sortEnumValue))
+                Settings.levelPreviewSortType = sortEnumValue;
+            else if (loadNode.name.Contains("filter") && EnumUtils.TryParse<FilterInfoType>(GetTerminalEventEnum(loadNode.terminalEvent), out FilterInfoType filterEnumValue))
             {
-                Settings.levelPreviewFilterType = (FilterInfoType)filterEnumValue;
+                Settings.levelPreviewFilterType = filterEnumValue;
                 currentTagFilter = GetTerminalEventString(loadNode.terminalEvent);
                 //DebugHelper.Log("Tag EventString: " + GetTerminalEventString(loadNode.terminalEvent));
             }

--- a/LethalLevelLoader/Plugin.cs
+++ b/LethalLevelLoader/Plugin.cs
@@ -19,6 +19,7 @@ namespace LethalLevelLoader
 {
     [BepInPlugin(ModGUID, ModName, ModVersion)]
     [BepInDependency(LethalLib.Plugin.ModGUID, BepInDependency.DependencyFlags.SoftDependency)]
+    [BepInDependency(LCEnumUtils.PluginInfo.ModGUID)]
     [BepInDependency(LethalModDataLib.PluginInfo.PLUGIN_GUID)]
     public class Plugin : BaseUnityPlugin
     {

--- a/LethalLevelLoader/Tools/AssetBundleLoader.cs
+++ b/LethalLevelLoader/Tools/AssetBundleLoader.cs
@@ -592,7 +592,7 @@ namespace LethalLevelLoader
 
         internal static void CreateVanillaExtendedWeatherEffects(StartOfRound startOfRound, TimeOfDay timeOfDay)
         {
-            foreach (LevelWeatherType levelWeatherType in Enum.GetValues(typeof(LevelWeatherType)))
+            foreach (LevelWeatherType levelWeatherType in EnumUtils.GetStaticValues<LevelWeatherType>())
             {
                 ExtendedWeatherEffect newExtendedWeatherEffect;
                 if (levelWeatherType != LevelWeatherType.None)

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
     "dependencies": [
         "Evaisa-FixPluginTypesSerialization-1.1.1",
         "MaxWasUnavailable-LethalModDataLib-1.2.2",
+        "MegaPiggy-EnumUtils-1.0.5",
         "BepInEx-BepInExPack-5.4.2100"
     ]
 }


### PR DESCRIPTION
Fix to grab only vanilla https://github.com/IAmBatby/LethalLevelLoader/commit/743def50ec0b86da52920046f154dae0af185c86

It is small but needed in case some other mod adds a weather type using Enum Utils. (i.e. lethal lib if the pr I made there gets accepted https://github.com/EvaisaDev/LethalLib/pull/91)
I wouldn't want it to just break one of the biggest libraries lol