### PR TITLE
Allocate less on strings when loading to the lobby

### DIFF
--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedLevel.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedLevel.cs
@@ -1,4 +1,5 @@
 ﻿using GameNetcodeStuff;
+using LethalLevelLoader.General;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -185,10 +186,20 @@ namespace LethalLevelLoader
 
         internal static string GetNumberlessPlanetName(SelectableLevel selectableLevel)
         {
-            if (selectableLevel != null)
-                return new string(selectableLevel.PlanetName.SkipWhile(c => !char.IsLetter(c)).ToArray());
-            else
+            if (selectableLevel == null)
+            {
                 return string.Empty;
+            }
+
+            var planetNameSpan = selectableLevel.PlanetName.AsSpan();
+            var trimmedName = planetNameSpan.TrimStartToLetters();
+
+            if (trimmedName.Equals(planetNameSpan, StringComparison.Ordinal))
+            {
+                return selectableLevel.PlanetName;
+            }
+
+            return trimmedName.ToString();
         }
 
         internal void SetLevelID()

--- a/LethalLevelLoader/Components/MatchingProperties/MatchingProperties.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/MatchingProperties.cs
@@ -22,7 +22,7 @@ namespace LethalLevelLoader
         {
             if (newValue > currentValue)
             {
-                if (!string.IsNullOrEmpty(debugActionReason))
+                if (!string.IsNullOrEmpty(debugActionReason) && DebugHelper.ShouldLog(DebugType.Developer))
                 {
                     if (!string.IsNullOrEmpty(debugActionObject))
                         DebugHelper.Log("Raised Rarity Of: " + debugActionObject + " From (" + currentValue + ") To (" + newValue + ") Due To Matching " + debugActionReason, DebugType.Developer);

--- a/LethalLevelLoader/Components/MatchingProperties/MatchingProperties.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/MatchingProperties.cs
@@ -60,10 +60,26 @@ namespace LethalLevelLoader
         {
             int returnInt = 0;
             foreach (StringWithRarity stringWithRarity in matchingStrings)
-                foreach (string comparingString in new List<string>(comparingStrings))
-                    if (stringWithRarity.Rarity >= returnInt)
-                        if (stringWithRarity.Name.Sanitized().Contains(comparingString.Sanitized()) || comparingString.Sanitized().Contains(stringWithRarity.Name.Sanitized()))
-                            returnInt = stringWithRarity.Rarity;
+            {
+                if (stringWithRarity.Rarity < returnInt)
+                {
+                    continue;
+                }
+
+                var stringNameSanitized = stringWithRarity.Name.Sanitized();
+                foreach (string comparingString in comparingStrings)
+                {
+                    var comparingStringSanitized = comparingString.Sanitized();
+
+                    if (stringNameSanitized.Contains(comparingStringSanitized)
+                        || comparingStringSanitized.Contains(stringNameSanitized))
+                    {
+                        returnInt = stringWithRarity.Rarity;
+                        break;
+                    }
+                }
+            }
+
             return (returnInt);
         }
     }

--- a/LethalLevelLoader/General/ArrayExtensions.cs
+++ b/LethalLevelLoader/General/ArrayExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace LethalLevelLoader.General;
+internal static class ArrayExtensions
+{
+    public static void AddItem<T>(ref T[] array, T item)
+    {
+        if (array == null)
+        {
+            array = new T[1] { item };
+            return;
+        }
+
+        Array.Resize(ref array, array.Length + 1);
+        array[array.Length - 1] = item;
+    }
+}

--- a/LethalLevelLoader/General/Extensions.cs
+++ b/LethalLevelLoader/General/Extensions.cs
@@ -90,22 +90,24 @@ namespace LethalLevelLoader
 
         public static void AddCompatibleNoun(this TerminalKeyword terminalKeyword, TerminalKeyword newNoun,  TerminalNode newResult)
         {
-            if (terminalKeyword.compatibleNouns == null)
-                terminalKeyword.compatibleNouns = new CompatibleNoun[0];
-            CompatibleNoun newCompataibleNoun = new CompatibleNoun();
-            newCompataibleNoun.noun = newNoun;
-            newCompataibleNoun.result = newResult;
-            terminalKeyword.compatibleNouns = terminalKeyword.compatibleNouns.AddItem(newCompataibleNoun).ToArray();
+            CompatibleNoun newCompataibleNoun = new CompatibleNoun
+            {
+                noun = newNoun,
+                result = newResult
+            };
+
+            ArrayExtensions.AddItem(ref terminalKeyword.compatibleNouns, newCompataibleNoun);
         }
 
         public static void AddCompatibleNoun(this TerminalNode terminalNode, TerminalKeyword newNoun, TerminalNode newResult)
         {
-            if (terminalNode.terminalOptions == null)
-                terminalNode.terminalOptions = new CompatibleNoun[0];
-            CompatibleNoun newCompataibleNoun = new CompatibleNoun();
-            newCompataibleNoun.noun = newNoun;
-            newCompataibleNoun.result = newResult;
-            terminalNode.terminalOptions = terminalNode.terminalOptions.AddItem(newCompataibleNoun).ToArray();
+            CompatibleNoun newCompataibleNoun = new CompatibleNoun
+            {
+                noun = newNoun,
+                result = newResult
+            };
+
+            ArrayExtensions.AddItem(ref terminalNode.terminalOptions, newCompataibleNoun);
         }
 
         public static void Add(this IntWithRarity intWithRarity, int id, int rarity)

--- a/LethalLevelLoader/General/Extensions.cs
+++ b/LethalLevelLoader/General/Extensions.cs
@@ -1,10 +1,12 @@
 ﻿using DunGen;
 using DunGen.Graph;
 using HarmonyLib;
+using LethalLevelLoader.General;
 using Mono.Cecil;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.ConstrainedExecution;
 using System.Text;
 using System.Text.RegularExpressions;
 using UnityEngine;
@@ -123,7 +125,17 @@ namespace LethalLevelLoader
 
         public static string RemoveWhitespace(this string input)
         {
-            return new string(input.ToCharArray().Where(c => !Char.IsWhiteSpace(c)).ToArray());
+            var inputSpan = input.AsSpan();
+            
+            if (!inputSpan.IsWhiteSpace())
+            {
+                return input;
+            }
+
+            var stringBuilder = new StringBuilder(input);
+            stringBuilder.Replace(" ", "");
+
+            return stringBuilder.ToString();
         }
 
         public static string SkipToLetters(this string input)

--- a/LethalLevelLoader/General/Extensions.cs
+++ b/LethalLevelLoader/General/Extensions.cs
@@ -140,7 +140,15 @@ namespace LethalLevelLoader
 
         public static string SkipToLetters(this string input)
         {
-            return new string(input.SkipWhile(c => !char.IsLetter(c)).ToArray());
+            var inputSpan = input.AsSpan();
+            var trimmedSpan = inputSpan.TrimStartToLetters();
+
+            if (inputSpan.Equals(trimmedSpan, StringComparison.Ordinal))
+            {
+                return input;
+            }
+
+            return trimmedSpan.ToString();
         }
 
         public static string StripSpecialCharacters(this string input)

--- a/LethalLevelLoader/General/Extensions.cs
+++ b/LethalLevelLoader/General/Extensions.cs
@@ -118,7 +118,7 @@ namespace LethalLevelLoader
 
         public static string Sanitized(this string currentString)
         {
-            return new string(currentString.SkipToLetters().RemoveWhitespace().ToLowerInvariant());
+            return (currentString.SkipToLetters().RemoveWhitespace().ToLowerInvariant());
         }
 
         public static string RemoveWhitespace(this string input)

--- a/LethalLevelLoader/General/Extensions.cs
+++ b/LethalLevelLoader/General/Extensions.cs
@@ -153,13 +153,23 @@ namespace LethalLevelLoader
 
         public static string StripSpecialCharacters(this string input)
         {
-            string returnString = string.Empty;
+            var stringBuilder = new StringBuilder();
 
-            foreach (char charmander in input)
-                if ((!ConfigHelper.illegalCharacters.ToCharArray().Contains(charmander) && char.IsLetterOrDigit(charmander)) || charmander.ToString() == " ")
-                    returnString += charmander;
+            foreach (var chr in input)
+            {
+                if ((!ConfigHelper.illegalCharacters.Contains(chr) && char.IsLetterOrDigit(chr))
+                    || chr == ' ')
+                {
+                    stringBuilder.Append(chr);
+                }
+            }
 
-            return returnString;
+            if (input.Length == stringBuilder.Length)
+            {
+                return input;
+            }
+
+            return stringBuilder.ToString();
         }
 
         public static List<DungeonFlow> GetDungeonFlows(this RoundManager roundManager)

--- a/LethalLevelLoader/General/Patches.cs
+++ b/LethalLevelLoader/General/Patches.cs
@@ -3,6 +3,7 @@ using DunGen;
 using DunGen.Graph;
 using GameNetcodeStuff;
 using HarmonyLib;
+using LethalLevelLoader.General;
 using LethalLevelLoader.Tools;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
@@ -184,7 +185,7 @@ namespace LethalLevelLoader
                 GameObject.Instantiate(LethalLevelLoaderNetworkManager.networkingManagerPrefab).GetComponent<NetworkObject>().Spawn(destroyWithScene: false);
 
             //Add the facility's firstTimeDungeonAudio additionally to RoundManager's list to fix a base game bug.
-            RoundManager.firstTimeDungeonAudios = RoundManager.firstTimeDungeonAudios.ToList().AddItem(RoundManager.firstTimeDungeonAudios[0]).ToArray();
+            ArrayExtensions.AddItem(ref RoundManager.firstTimeDungeonAudios, RoundManager.firstTimeDungeonAudios[0]);
             DebugStopwatch.StartStopWatch("Fix AudioSource Settings");
             //Disable Spatialization In All AudioSources To Fix Log Spam Bug.
             foreach (AudioSource audioSource in Resources.FindObjectsOfTypeAll<AudioSource>())

--- a/LethalLevelLoader/General/SpanExtensions.cs
+++ b/LethalLevelLoader/General/SpanExtensions.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace LethalLevelLoader.General;
+internal static class SpanExtensions
+{
+    public static bool IsLettersOrDigits(this ReadOnlySpan<char> span)
+    {
+        for (var i = 0; i < span.Length; i++)
+        {
+            if (char.IsLetterOrDigit(span[i]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static bool IsLetters(this ReadOnlySpan<char> span)
+    {
+        for (var i = 0; i < span.Length; i++)
+        {
+            if (char.IsLetter(span[i]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static ReadOnlySpan<char> TrimStartToLetters(this ReadOnlySpan<char> span)
+    {
+        var startIndex = 0;
+        for (var i = 0; i < span.Length; i++)
+        {
+            if (char.IsLetter(span[i]))
+            {
+                break;
+            }
+
+            startIndex++;
+        }
+
+        return span.Slice(startIndex);
+    }
+}

--- a/LethalLevelLoader/General/StringBuilderExtensions.cs
+++ b/LethalLevelLoader/General/StringBuilderExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Text;
+
+namespace LethalLevelLoader.General;
+internal static class StringBuilderExtensions
+{
+    public static StringBuilder TrimEnd(this StringBuilder sb, char trimChar)
+    {
+        if (sb.Length == 0)
+        {
+            return sb;
+        }
+
+        var startIndex = sb.Length - 1;
+        while (startIndex >= 0 && sb[startIndex] == trimChar)
+        {
+            startIndex--;
+        }
+
+        sb.Length = startIndex + 1;
+        return sb;
+    }
+
+    public static StringBuilder AppendValue(this StringBuilder sb, int value)
+    {
+        // StringBuilder.Append(T) allocates string under the hood in Mono, using Span<char> to prevent that
+        Span<char> buffer = stackalloc char[32];
+        value.TryFormat(buffer, out var charsWritten);
+
+        sb.Append(buffer.Slice(0, charsWritten));
+        return sb;
+    }
+
+    public static StringBuilder AppendValue(this StringBuilder sb, float value)
+    {
+        Span<char> buffer = stackalloc char[32];
+        value.TryFormat(buffer, out var charsWritten);
+
+        sb.Append(buffer.Slice(0, charsWritten));
+        return sb;
+    }
+}

--- a/LethalLevelLoader/Patches/DungeonManager.cs
+++ b/LethalLevelLoader/Patches/DungeonManager.cs
@@ -1,6 +1,7 @@
 ﻿using DunGen;
 using DunGen.Graph;
 using HarmonyLib;
+using LethalLevelLoader.General;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,9 +33,9 @@ namespace LethalLevelLoader
                 IndoorMapType newIndoorMapType = new IndoorMapType();
                 newIndoorMapType.dungeonFlow = extendedDungeonFlow.DungeonFlow;
                 newIndoorMapType.MapTileSize = extendedDungeonFlow.MapTileSize;
-                Patches.RoundManager.dungeonFlowTypes = Patches.RoundManager.dungeonFlowTypes.AddItem(newIndoorMapType).ToArray();
+                ArrayExtensions.AddItem(ref Patches.RoundManager.dungeonFlowTypes, newIndoorMapType);
                 if (extendedDungeonFlow.FirstTimeDungeonAudio != null)
-                    Patches.RoundManager.firstTimeDungeonAudios = Patches.RoundManager.firstTimeDungeonAudios.AddItem(extendedDungeonFlow.FirstTimeDungeonAudio).ToArray();
+                    ArrayExtensions.AddItem(ref Patches.RoundManager.firstTimeDungeonAudios, extendedDungeonFlow.FirstTimeDungeonAudio);
             }
         }
 

--- a/LethalLevelLoader/Patches/TerminalManager.cs
+++ b/LethalLevelLoader/Patches/TerminalManager.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using JetBrains.Annotations;
+using LethalLevelLoader.General;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -807,7 +808,7 @@ namespace LethalLevelLoader
             extendedItem.BuyConfirmNode = terminalNodeBuyConfirm;
             extendedItem.BuyInfoNode = terminalNodeInfo;
 
-            Terminal.buyableItemsList = Terminal.buyableItemsList.AddItem(extendedItem.Item).ToArray();
+            ArrayExtensions.AddItem(ref Terminal.buyableItemsList, extendedItem.Item);
         }
 
         internal static void CreateEnemyTypeTerminalData(ExtendedEnemyType extendedEnemyType)
@@ -982,7 +983,7 @@ namespace LethalLevelLoader
 
             newTerminalKeyword.compatibleNouns = new CompatibleNoun[0];
             newTerminalKeyword.defaultVerb = null;
-            Terminal.terminalNodes.allKeywords = Terminal.terminalNodes.allKeywords.AddItem(newTerminalKeyword).ToArray();
+            ArrayExtensions.AddItem(ref Terminal.terminalNodes.allKeywords, newTerminalKeyword);
 
             return (newTerminalKeyword);
         }

--- a/LethalLevelLoader/Tools/ConfigHelper.cs
+++ b/LethalLevelLoader/Tools/ConfigHelper.cs
@@ -1,7 +1,9 @@
 ﻿using BepInEx.Configuration;
 using HarmonyLib;
+using LethalLevelLoader.General;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using UnityEngine;
@@ -141,16 +143,22 @@ namespace LethalLevelLoader
 
         public static string SpawnableEnemiesWithRaritiesToString(List<SpawnableEnemyWithRarity> spawnableEnemiesList)
         {
-            string returnString = string.Empty;
+            var stringBuilder = new StringBuilder();
 
             foreach (SpawnableEnemyWithRarity spawnableEnemyWithRarity in spawnableEnemiesList)
-                returnString += spawnableEnemyWithRarity.enemyType.enemyName + ConfigHelper.keyPairSeperator + spawnableEnemyWithRarity.rarity.ToString() + ConfigHelper.indexSeperator;
-            if (returnString.Contains(",") && returnString.LastIndexOf(",") == (returnString.Length - 1))
-                returnString = returnString.Remove(returnString.LastIndexOf(","), 1);
+            {
+                stringBuilder.Append(spawnableEnemyWithRarity.enemyType.enemyName)
+                    .Append(keyPairSeperator)
+                    .AppendValue(spawnableEnemyWithRarity.rarity)
+                    .Append(indexSeperator);
+            }
 
-            if (returnString == string.Empty)
-                returnString = "Default Values Were Empty";
-            return (returnString);
+            stringBuilder.TrimEnd(',');
+
+            if (stringBuilder.Length == 0)
+                return "Default Values Were Empty";
+
+            return (stringBuilder.ToString());
         }
 
         public static string SpawnableItemsWithRaritiesToString(List<SpawnableItemWithRarity> spawnableItemsList)

--- a/LethalLevelLoader/Tools/ConfigHelper.cs
+++ b/LethalLevelLoader/Tools/ConfigHelper.cs
@@ -185,18 +185,23 @@ namespace LethalLevelLoader
 
         public static string Vector2WithRaritiesToString(List<Vector2WithRarity> values)
         {
-            string returnString = string.Empty;
+            var stringBuilder = new StringBuilder();
 
             foreach (Vector2WithRarity vector2withRarity in values)
-                returnString += vector2withRarity.Min + vectorSeperator + vector2withRarity.Max + keyPairSeperator + vector2withRarity.Rarity + indexSeperator;
+            {
+                stringBuilder.AppendValue(vector2withRarity.Min)
+                    .Append(vectorSeperator)
+                    .AppendValue(vector2withRarity.Max)
+                    .AppendValue(vector2withRarity.Rarity)
+                    .Append(indexSeperator);
+            }
 
-            if (returnString.Contains(",") && returnString.LastIndexOf(",") == (returnString.Length - 1))
-                returnString = returnString.Remove(returnString.LastIndexOf(","), 1);
+            stringBuilder.TrimEnd(',');
 
-            if (returnString == string.Empty)
-                returnString = "Default Values Were Empty";
+            if (stringBuilder.Length == 0)
+                return "Default Values Were Empty";
 
-            return (returnString);
+            return (stringBuilder.ToString());
         }
 
         public static List<string> SplitStringsByIndexSeperator(string newInputString)

--- a/LethalLevelLoader/Tools/ConfigHelper.cs
+++ b/LethalLevelLoader/Tools/ConfigHelper.cs
@@ -169,18 +169,22 @@ namespace LethalLevelLoader
 
         public static string StringWithRaritiesToString(List<StringWithRarity> names)
         {
-            string returnString = string.Empty;
+            var stringBuilder = new StringBuilder();
 
             foreach (StringWithRarity name in names)
-                returnString += name.Name + ConfigHelper.keyPairSeperator + name.Rarity.ToString() + ConfigHelper.indexSeperator;
+            {
+                stringBuilder.Append(name.Name)
+                    .Append(keyPairSeperator)
+                    .AppendValue(name.Rarity)
+                    .Append(indexSeperator);
+            }
 
-            if (returnString.Contains(",") && returnString.LastIndexOf(",") == (returnString.Length - 1))
-                returnString = returnString.Remove(returnString.LastIndexOf(","), 1);
+            stringBuilder.TrimEnd(',');
 
-            if (returnString == string.Empty)
-                returnString = "Default Values Were Empty";
+            if (stringBuilder.Length == 0)
+                return "Default Values Were Empty";
 
-            return (returnString);
+            return (stringBuilder.ToString());
         }
 
         public static string Vector2WithRaritiesToString(List<Vector2WithRarity> values)

--- a/LethalLevelLoader/Tools/ConfigHelper.cs
+++ b/LethalLevelLoader/Tools/ConfigHelper.cs
@@ -155,16 +155,22 @@ namespace LethalLevelLoader
 
         public static string SpawnableItemsWithRaritiesToString(List<SpawnableItemWithRarity> spawnableItemsList)
         {
-            string returnString = string.Empty;
+            var stringBuilder = new StringBuilder();
 
             foreach (SpawnableItemWithRarity spawnableItemWithRarity in spawnableItemsList)
-                returnString += spawnableItemWithRarity.spawnableItem.itemName + ConfigHelper.keyPairSeperator + spawnableItemWithRarity.rarity.ToString() + ConfigHelper.indexSeperator;
-            if (returnString.Contains(",") && returnString.LastIndexOf(",") == (returnString.Length - 1))
-                returnString = returnString.Remove(returnString.LastIndexOf(","), 1);
+            {
+                stringBuilder.Append(spawnableItemWithRarity.spawnableItem.itemName)
+                    .Append(keyPairSeperator)
+                    .AppendValue(spawnableItemWithRarity.rarity)
+                    .Append(indexSeperator);
+            }
 
-            if (returnString == string.Empty)
-                returnString = "Default Values Were Empty";
-            return (returnString);
+            stringBuilder.TrimEnd(',');
+
+            if (stringBuilder.Length == 0)
+                return "Default Values Were Empty";
+
+            return (stringBuilder.ToString());
         }
 
         public static string StringWithRaritiesToString(List<StringWithRarity> names)

--- a/LethalLevelLoader/Tools/ConfigHelper.cs
+++ b/LethalLevelLoader/Tools/ConfigHelper.cs
@@ -242,9 +242,10 @@ namespace LethalLevelLoader
             }
         }
 
+        [Obsolete("Use " + nameof(Extensions) + "." + nameof(Extensions.Sanitized))]
         public static string SanitizeString(string inputString)
         {
-            return (inputString.SkipToLetters().RemoveWhitespace().ToLower());
+            return inputString.Sanitized();
         }
     }
 }

--- a/LethalLevelLoader/Tools/ConfigLoader.cs
+++ b/LethalLevelLoader/Tools/ConfigLoader.cs
@@ -130,11 +130,14 @@ namespace LethalLevelLoader.Tools
                 minimumDungeonSizeMultiplier = BindValue("Minimum Dungeon Size Multiplier", "If The Level's Dungeon Size Multiplier Is Below This Value, The Size Multiplier Will Be Restricted Based On The RestrictDungeonSizeScaler Setting", extendedDungeonFlow.DynamicDungeonSizeMinMax.x);
                 maximumDungeonSizeMultiplier = BindValue("Maximum Dungeon Size Multiplier", "If The Level's Dungeon Size Multiplier Is Above This Value, The Size Multiplier Will Be Restricted Based On The RestrictDungeonSizeScaler Setting", extendedDungeonFlow.DynamicDungeonSizeMinMax.y);
 
-                string description = "If The Level's Dungeon Size Multiplier Is Above Or Below The Previous Two Settings, The Dungeon Size Multiplier Will Be Set To The Value Between The Level's Dungeon Size Multiplier And This Value." + "\n";
-                description += "Example #1: If Set To 0, The Dungeon Size Will Not Be Higher Than Maximum Dungeon Size Multiplier." + "\n";
-                description += "Example #2: If Set To 0.5, The Dungeon Size Will Be Between The Maxiumum Dungeon Size Multiplier And The Level's Dungeon Size Multiplier." + "\n";
-                description += "Example #3: If Set To 1, The Dungeon Size Will Be The Level's Dungeon Size Multiplier With No Changes Applied." + "\n";
-                description += "(Minimum, 0, Maximum: 1)";
+                const string description = """
+                    If The Level's Dungeon Size Multiplier Is Above Or Below The Previous Two Settings, The Dungeon Size Multiplier Will Be Set To The Value Between The Level's Dungeon Size Multiplier And This Value.
+                    Example #1: If Set To 0, The Dungeon Size Will Not Be Higher Than Maximum Dungeon Size Multiplier.
+                    Example #2: If Set To 0.5, The Dungeon Size Will Be Between The Maxiumum Dungeon Size Multiplier And The Level's Dungeon Size Multiplier.
+                    Example #3: If Set To 1, The Dungeon Size Will Be The Level's Dungeon Size Multiplier With No Changes Applied.
+                    (Minimum, 0, Maximum: 1)
+                    """;
+
                 restrictDungeonSizeScaler = BindValue("Restrict Dungeon Size Scaler", description, extendedDungeonFlow.DynamicDungeonSizeLerpRate);
 
                 // ----- Getting -----
@@ -171,8 +174,10 @@ namespace LethalLevelLoader.Tools
             }
             else
             {
-                string description = "The author of this content has chosen not to allow for LethalLevelLoader to generate a custom configuration template for them." + "\n";
-                description += "This is likely due to said content author providing alternative configuration options in their own Config.";
+                const string description = """
+                    The author of this content has chosen not to allow for LethalLevelLoader to generate a custom configuration template for them.
+                    This is likely due to said content author providing alternative configuration options in their own Config.
+                    """;
                 enableContentConfiguration = BindValue("Content Author Disabled Automatic Configuration File Warning", description, false);
             }
         }
@@ -286,9 +291,11 @@ namespace LethalLevelLoader.Tools
             }
             else
             {
-                string description = "The author of this content has chosen not to allow for LethalLevelLoader to generate a custom configuration template for them." + "\n";
-                description += "This is likely due to said content author providing alternative configuration options in their own Config.";
-                enableContentConfiguration = BindValue("Content Author Disabled Automatic Configuration File Warning", description, false);
+                const string Description = """
+                    The author of this content has chosen not to allow for LethalLevelLoader to generate a custom configuration template for them.
+                    This is likely due to said content author providing alternative configuration options in their own Config.
+                    """;
+                enableContentConfiguration = BindValue("Content Author Disabled Automatic Configuration File Warning", Description, false);
             }
         }
     }

--- a/LethalLevelLoader/Tools/ConfigLoader.cs
+++ b/LethalLevelLoader/Tools/ConfigLoader.cs
@@ -12,8 +12,6 @@ namespace LethalLevelLoader.Tools
 {
     internal static class ConfigLoader
     {
-        public static string debugLevelsString = string.Empty;
-        public static string debugDungeonsString = string.Empty;
         public static ConfigFile configFile;
 
         internal static void BindConfigs()
@@ -46,15 +44,6 @@ namespace LethalLevelLoader.Tools
                 ExtendedLevelConfig newConfig = new ExtendedLevelConfig(configFile, "Custom Level:  " + extendedLevel.SelectableLevel.PlanetName.StripSpecialCharacters(), 8);
                 newConfig.BindConfigs(extendedLevel);
             }
-
-            if (debugLevelsString.Contains(", ") && debugLevelsString.LastIndexOf(", ") == (debugLevelsString.Length - 2))
-                debugLevelsString = debugLevelsString.Remove(debugLevelsString.LastIndexOf(", "), 2);
-
-            if (debugDungeonsString.Contains(", ") && debugDungeonsString.LastIndexOf(", ") == (debugDungeonsString.Length - 2))
-                debugDungeonsString = debugDungeonsString.Remove(debugDungeonsString.LastIndexOf(", "), 2);
-
-            debugLevelsString = string.Empty;
-            debugDungeonsString = string.Empty;
         }
 
         internal static void BindGeneralConfigs()
@@ -293,8 +282,6 @@ namespace LethalLevelLoader.Tools
                     selectableLevel.Enemies = ConfigHelper.ConvertToSpawnableEnemyWithRarityList(insideEnemiesOverrides.Value, new Vector2(0, 100));
                     selectableLevel.DaytimeEnemies = ConfigHelper.ConvertToSpawnableEnemyWithRarityList(outsideDaytimeEnemiesOverrides.Value, new Vector2(0, 100));
                     selectableLevel.OutsideEnemies = ConfigHelper.ConvertToSpawnableEnemyWithRarityList(outsideNighttimeEnemiesOverrides.Value, new Vector2(0, 100));
-
-                    ConfigLoader.debugLevelsString += selectableLevel.PlanetName + ", ";
                 }
             }
             else

--- a/LethalLevelLoader/Tools/ConfigLoader.cs
+++ b/LethalLevelLoader/Tools/ConfigLoader.cs
@@ -327,10 +327,13 @@ namespace LethalLevelLoader.Tools
 
         public string GetSortingSpaces()
         {
-            string returnString = string.Empty;
-            for (int i = 0; i < sortingPriority; i++)
-                returnString += "​"; //Zero Width Space In Here, Do Not Let It Escape!
-            return returnString;
+            if (sortingPriority == 0)
+            {
+                return string.Empty;
+            }
+
+            const char ZeroWidthChar = (char)0x200b;
+            return new string(ZeroWidthChar, sortingPriority);
         }
     }
 }

--- a/LethalLevelLoader/Tools/ConfigLoader.cs
+++ b/LethalLevelLoader/Tools/ConfigLoader.cs
@@ -173,13 +173,11 @@ namespace LethalLevelLoader.Tools
                     extendedDungeonFlow.LevelMatchingProperties.currentRoutePrice = ConfigHelper.ConvertToVector2WithRarityList(dynamicRoutePrices.Value, new Vector2(0, 9999));
                     extendedDungeonFlow.LevelMatchingProperties.levelTags = ConfigHelper.ConvertToStringWithRarityList(dynamicLevelTags.Value, new Vector2(0, 9999));
 
-                    foreach (StringWithRarity stringWithRarity in ConfigHelper.ConvertToStringWithRarityList(dynamicLevelTags.Value, new Vector2(0, 9999)))
-                        DebugHelper.Log(stringWithRarity.Name + " | " + stringWithRarity.Rarity, DebugType.Developer);
-
-                    if (extendedDungeonFlow.ContentType == ContentType.Vanilla)
-                        ConfigLoader.debugDungeonsString += extendedDungeonFlow.DungeonName +  "(" + extendedDungeonFlow.DungeonFlow.name + ")" + ", ";
-                    else if (extendedDungeonFlow.ContentType == ContentType.Custom)
-                        ConfigLoader.debugDungeonsString += extendedDungeonFlow.DungeonName + ", ";
+                    if (DebugHelper.ShouldLog(DebugType.Developer))
+                    {
+                        foreach (StringWithRarity stringWithRarity in extendedDungeonFlow.LevelMatchingProperties.levelTags)
+                            DebugHelper.Log(stringWithRarity.Name + " | " + stringWithRarity.Rarity, DebugType.Developer);
+                    }
                 }
             }
             else

--- a/LethalLevelLoader/Tools/DebugHelper.cs
+++ b/LethalLevelLoader/Tools/DebugHelper.cs
@@ -609,6 +609,11 @@ namespace LethalLevelLoader
 
         public static void DebugExtendedMod(ExtendedMod extendedMod)
         {
+            if (!ShouldLog(DebugType.Developer))
+            {
+                return;
+            }
+
             string debugString = "Debug Report For ExtendedMod: " + extendedMod.ModName + " by " + extendedMod.AuthorName + "\n";
 
             debugString += "\nExtendedContents: Count - " + extendedMod.ExtendedContents.Count + "\n";
@@ -620,6 +625,11 @@ namespace LethalLevelLoader
 
         public static void DebugAllContentTags()
         {
+            if (!ShouldLog(DebugType.Developer))
+            {
+                return;
+            }
+
             foreach (ExtendedMod extendedMod in PatchedContent.ExtendedMods.Concat(new List<ExtendedMod>() { PatchedContent.VanillaMod }))
             {
                 List<ContentTag> foundContentTags = new List<ContentTag>();

--- a/LethalLevelLoader/Tools/DebugHelper.cs
+++ b/LethalLevelLoader/Tools/DebugHelper.cs
@@ -24,6 +24,11 @@ namespace LethalLevelLoader
         public static Dictionary<ExtendedLevel, ExtendedLevelLogReport> extendedLevelLogReports = new Dictionary<ExtendedLevel, ExtendedLevelLogReport>();
         public static Dictionary<ExtendedDungeonFlow, ExtendedLevelLogReport> extendedDungeonFlowLogReports = new Dictionary<ExtendedDungeonFlow, ExtendedLevelLogReport>();
 
+        public static bool ShouldLog(DebugType debugType)
+        {
+            return Settings.debugType >= debugType;
+        }
+
         public static void Log(string log, DebugType debugType)
         {
             if (!string.IsNullOrEmpty(log) && (int)Settings.debugType >= (int)debugType)

--- a/LethalLevelLoader/Tools/DebugStopwatch.cs
+++ b/LethalLevelLoader/Tools/DebugStopwatch.cs
@@ -12,6 +12,11 @@ namespace LethalLevelLoader
 
         internal static void StartStopWatch(string newStopWatchText, bool stopPreviousStopWatch = true)
         {
+            if (Settings.debugType < DebugType.IAmBatby)
+            {
+                return;
+            }
+
             if (!stopWatchDict.ContainsKey(newStopWatchText))
             {
                 if (stopPreviousStopWatch == true && stopWatchDict.Count > 0)


### PR DESCRIPTION
Here some stats from Lunx profile
| ~ | GC allocations | Execution time |
|--------|--------|--------|
| Before | 250MB | 13sec |
| After | 100MB |  6sec |

Recommend to view changes by commits.