### PR TITLE
publicize defaultTerminalFontSize

### DIFF
--- a/LethalLevelLoader/Patches/TerminalManager.cs
+++ b/LethalLevelLoader/Patches/TerminalManager.cs
@@ -42,7 +42,7 @@ namespace LethalLevelLoader
 
         internal static string currentTagFilter;
 
-        internal static float defaultTerminalFontSize;
+        public static float defaultTerminalFontSize; //allow for other mods to access this variable/change it
 
         internal static TerminalKeyword lastParsedVerbKeyword;
 


### PR DESCRIPTION
would allow for other mods to access/modify this value to change terminal font size

specifically re: the below issue

`hey @IAmBatby (On Semi-Cooldown), low priority but I've got an issue to report. There's a feature in my terminal mod that allows for changing the terminal font & font size that is failing to update (Terminal instance).screenText.textComponent.fontSize with LLL present. I'm assuming it's because LLL caches the default font size at StartOfRound Awake and is setting the font size to this whenever RefreshMoonsCataloguePage is called. Is there any way I can build soft compatibility to LLL to either A) Update the cached font size to the user's configured size from my mod or B) subscribe to an event where RefreshMoonsCataloguePage is called to update the font size to the user's configured size from my mod after?`