### PR TITLE
Fix Debug build if Release hasn't been built; Fix Release build if path has spaces

### DIFF
--- a/LethalLevelLoader/LethalLevelLoader.csproj
+++ b/LethalLevelLoader/LethalLevelLoader.csproj
@@ -91,13 +91,13 @@
 
     <MakeDir Directories="$(ProjectDir)../assets/bundles" Condition="!Exists('$(ProjectDir)../assets/bundles')" />
 
-    <Exec Command="dotnet tcli build --config-path $(ProjectDir)../assets/thunderstore.toml --package-version $(PlainVersion)" />
+    <Exec Command="dotnet tcli build --config-path &quot;$(ProjectDir)../assets/thunderstore.toml&quot; --package-version $(PlainVersion)" />
 
   </Target>
 
       <!-- thunderstore publish -->
   <Target Name="PublishThunderstore" DependsOnTargets="SetPluginVersion;SaveVersionAndNameToFiles">
-      <Exec Command="dotnet tcli publish --config-path $(ProjectDir)../assets/thunderstore.toml --file $(ProjectDir)dist/*-$(MinVerVersion).zip" />
+      <Exec Command="dotnet tcli publish --config-path &quot;$(ProjectDir)../assets/thunderstore.toml&quot; --file &quot;$(ProjectDir)dist/*-$(MinVerVersion).zip&quot;" />
   </Target>
 
     <!-- zipping the .dll alone for curseforge release -->

--- a/LethalLevelLoader/LethalLevelLoader.csproj
+++ b/LethalLevelLoader/LethalLevelLoader.csproj
@@ -101,7 +101,7 @@
   </Target>
 
     <!-- zipping the .dll alone for curseforge release -->
-  <Target Name="ZipCurseForge" AfterTargets="PackThunderstore">
+  <Target Name="ZipCurseForge" DependsOnTargets="PackThunderstore">
     <MakeDir Directories="$(ProjectDir)dist/output/" Condition="!Exists('$(ProjectDir)dist/output/')" />
     <Copy SourceFiles="$(ProjectDir)bin/Release/netstandard2.1/$(AssemblyName).dll" DestinationFiles="$(ProjectDir)dist/output/$(AssemblyName).dll" />
 


### PR DESCRIPTION
Seems like `AfterTargets` runs in any case, but makes sure it's run after the target. `DependsOnTargets` also runs after the target, *but only if the target has ran,* otherwise it doesn't run. https://learn.microsoft.com/en-us/visualstudio/msbuild/target-build-order