### PR TITLE
Support multiple property matching implementations

### DIFF
--- a/LethalLevelLoader/Components/MatchingProperties/DungeonMatchingProperties.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/DungeonMatchingProperties.cs
@@ -21,21 +21,21 @@ namespace LethalLevelLoader
 
         public int GetDynamicRarity(ExtendedDungeonFlow extendedDungeonFlow)
         {
-            activePropertyMatcher ??= new HighestRarityPropertyMatcher();
+            PropertyMatcher propertyMatcher = GetPropertyMatcher();
 
             int returnRarity = baseRarity;
 
-            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedTags(extendedDungeonFlow.ContentTags, dungeonNames))
-                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedDungeonFlow.name, "Content Tags");
+            foreach (int value in propertyMatcher.GetRaritiesViaMatchingNormalizedTags(extendedDungeonFlow.ContentTags, dungeonNames))
+                propertyMatcher.UpdateRarity(ref returnRarity, value, extendedDungeonFlow.name, "Content Tags");
 
-            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedDungeonFlow.AuthorName, authorNames))
-                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedDungeonFlow.name, "Author Name");
+            foreach (int value in propertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedDungeonFlow.AuthorName, authorNames))
+                propertyMatcher.UpdateRarity(ref returnRarity, value, extendedDungeonFlow.name, "Author Name");
 
-            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedStrings(extendedDungeonFlow.ExtendedMod.ModNameAliases, modNames))
-                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedDungeonFlow.name, "Mod Name Name");
+            foreach (int value in propertyMatcher.GetRaritiesViaMatchingNormalizedStrings(extendedDungeonFlow.ExtendedMod.ModNameAliases, modNames))
+                propertyMatcher.UpdateRarity(ref returnRarity, value, extendedDungeonFlow.name, "Mod Name Name");
 
-            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedDungeonFlow.DungeonFlow.name, dungeonNames))
-                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedDungeonFlow.name, "Dungeon Name");
+            foreach (int value in propertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedDungeonFlow.DungeonFlow.name, dungeonNames))
+                propertyMatcher.UpdateRarity(ref returnRarity, value, extendedDungeonFlow.name, "Dungeon Name");
 
             return (returnRarity);
         }

--- a/LethalLevelLoader/Components/MatchingProperties/DungeonMatchingProperties.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/DungeonMatchingProperties.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using LethalLevelLoader.Components.MatchingProperties.PropertyMatchers;
 using UnityEngine;
 
 namespace LethalLevelLoader
@@ -17,18 +18,27 @@ namespace LethalLevelLoader
             dungeonMatchingProperties.name = extendedContent.name + "DungeonMatchingProperties";
             return (dungeonMatchingProperties);
         }
+
         public int GetDynamicRarity(ExtendedDungeonFlow extendedDungeonFlow)
         {
-            int returnRarity = 0;
+            activePropertyMatcher ??= new HighestRarityPropertyMatcher();
 
-            UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedTags(extendedDungeonFlow.ContentTags, dungeonNames), extendedDungeonFlow.name, "Content Tags");
-            UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedString(extendedDungeonFlow.AuthorName, authorNames), extendedDungeonFlow.name, "Author Name");
-            UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedStrings(extendedDungeonFlow.ExtendedMod.ModNameAliases, modNames), extendedDungeonFlow.name, "Mod Name Name");
-            UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedString(extendedDungeonFlow.DungeonFlow.name, dungeonNames), extendedDungeonFlow.name, "Dungeon Name");
+            int returnRarity = baseRarity;
+
+            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedTags(extendedDungeonFlow.ContentTags, dungeonNames))
+                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedDungeonFlow.name, "Content Tags");
+
+            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedDungeonFlow.AuthorName, authorNames))
+                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedDungeonFlow.name, "Author Name");
+
+            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedStrings(extendedDungeonFlow.ExtendedMod.ModNameAliases, modNames))
+                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedDungeonFlow.name, "Mod Name Name");
+
+            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedDungeonFlow.DungeonFlow.name, dungeonNames))
+                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedDungeonFlow.name, "Dungeon Name");
 
             return (returnRarity);
         }
-
 
         public void ApplyValues(List<StringWithRarity> newModNames = null, List<StringWithRarity> newAuthorNames = null, List<StringWithRarity> newDungeonTags = null, List<StringWithRarity> newDungeonNames = null)
         {

--- a/LethalLevelLoader/Components/MatchingProperties/LevelMatchingProperties.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/LevelMatchingProperties.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
+using LethalLevelLoader.Components.MatchingProperties.PropertyMatchers;
 using UnityEngine;
 
 namespace LethalLevelLoader
@@ -22,15 +21,27 @@ namespace LethalLevelLoader
 
         public int GetDynamicRarity(ExtendedLevel extendedLevel)
         {
-            int returnRarity = 0;
+            activePropertyMatcher ??= new HighestRarityPropertyMatcher();
 
-            UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedTags(extendedLevel.ContentTags, levelTags), extendedLevel.name, "Content Tags");
-            UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedString(extendedLevel.AuthorName, authorNames), extendedLevel.name, "Author Name");
-            UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedStrings(extendedLevel.ExtendedMod.ModNameAliases, modNames), extendedLevel.name, "Mod Name");
-            UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingWithinRanges(extendedLevel.RoutePrice, currentRoutePrice), extendedLevel.name, "Route Price");
-            UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedString(extendedLevel.NumberlessPlanetName, planetNames), extendedLevel.name, "Planet Name");
-            UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedString(extendedLevel.SelectableLevel.currentWeather.ToString(), currentWeather), extendedLevel.name, "Current Weather");
+            int returnRarity = baseRarity;
 
+            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedTags(extendedLevel.ContentTags, levelTags))
+                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Content Tags");
+
+            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedLevel.AuthorName, authorNames))
+                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Author Name");
+
+            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedStrings(extendedLevel.ExtendedMod.ModNameAliases, modNames))
+                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Mod Name");
+
+            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingWithinRanges(extendedLevel.RoutePrice, currentRoutePrice))
+                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Route Price");
+            
+            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedLevel.NumberlessPlanetName, planetNames))
+                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Planet Name");
+            
+            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedLevel.SelectableLevel.currentWeather.ToString(), currentWeather))
+                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Current Weather");
 
             return (returnRarity);
         }

--- a/LethalLevelLoader/Components/MatchingProperties/LevelMatchingProperties.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/LevelMatchingProperties.cs
@@ -21,27 +21,27 @@ namespace LethalLevelLoader
 
         public int GetDynamicRarity(ExtendedLevel extendedLevel)
         {
-            activePropertyMatcher ??= new HighestRarityPropertyMatcher();
+            PropertyMatcher propertyMatcher = GetPropertyMatcher();
 
             int returnRarity = baseRarity;
 
-            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedTags(extendedLevel.ContentTags, levelTags))
-                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Content Tags");
+            foreach (int value in propertyMatcher.GetRaritiesViaMatchingNormalizedTags(extendedLevel.ContentTags, levelTags))
+                propertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Content Tags");
 
-            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedLevel.AuthorName, authorNames))
-                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Author Name");
+            foreach (int value in propertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedLevel.AuthorName, authorNames))
+                propertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Author Name");
 
-            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedStrings(extendedLevel.ExtendedMod.ModNameAliases, modNames))
-                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Mod Name");
+            foreach (int value in propertyMatcher.GetRaritiesViaMatchingNormalizedStrings(extendedLevel.ExtendedMod.ModNameAliases, modNames))
+                propertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Mod Name");
 
-            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingWithinRanges(extendedLevel.RoutePrice, currentRoutePrice))
-                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Route Price");
+            foreach (int value in propertyMatcher.GetRaritiesViaMatchingWithinRanges(extendedLevel.RoutePrice, currentRoutePrice))
+                propertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Route Price");
             
-            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedLevel.NumberlessPlanetName, planetNames))
-                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Planet Name");
+            foreach (int value in propertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedLevel.NumberlessPlanetName, planetNames))
+                propertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Planet Name");
             
-            foreach (int value in activePropertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedLevel.SelectableLevel.currentWeather.ToString(), currentWeather))
-                activePropertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Current Weather");
+            foreach (int value in propertyMatcher.GetRaritiesViaMatchingNormalizedString(extendedLevel.SelectableLevel.currentWeather.ToString(), currentWeather))
+                propertyMatcher.UpdateRarity(ref returnRarity, value, extendedLevel.name, "Current Weather");
 
             return (returnRarity);
         }

--- a/LethalLevelLoader/Components/MatchingProperties/MatchingProperties.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/MatchingProperties.cs
@@ -8,16 +8,33 @@ namespace LethalLevelLoader
     public class MatchingProperties : ScriptableObject
     {
         [Space(5)] public int baseRarity = 0;
+        [Space(5)] public PropertyMatcherType propertyMatcherType = PropertyMatcherType.HighestRarity;
         [Space(5)] public List<StringWithRarity> modNames = new List<StringWithRarity>();
         [Space(5)] public List<StringWithRarity> authorNames = new List<StringWithRarity>();
 
-        [NonSerialized] public PropertyMatcher activePropertyMatcher;
+        private PropertyMatcher _propertyMatcher;
 
         public static MatchingProperties Create(ExtendedContent extendedContent)
         {
             MatchingProperties matchingProperties = ScriptableObject.CreateInstance<MatchingProperties>();
             matchingProperties.name = extendedContent.name + "MatchingProperties";
             return (matchingProperties);
+        }
+
+        internal PropertyMatcher GetPropertyMatcher()
+        {
+            if (_propertyMatcher is not null)
+                return _propertyMatcher;
+
+            _propertyMatcher = propertyMatcherType switch
+            {
+                PropertyMatcherType.HighestRarity => new HighestRarityPropertyMatcher(),
+                PropertyMatcherType.Multiplier => new MultiplierPropertyMatcher(),
+                _ => throw new NotImplementedException(
+                    $"Only PropertyMatchers of type {nameof(PropertyMatcherType.HighestRarity)} and {nameof(PropertyMatcherType.Multiplier)} are supported."),
+            };
+
+            return _propertyMatcher;
         }
     }
 }

--- a/LethalLevelLoader/Components/MatchingProperties/MatchingProperties.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/MatchingProperties.cs
@@ -1,70 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using LethalLevelLoader.Components.MatchingProperties.PropertyMatchers;
 using UnityEngine;
 
 namespace LethalLevelLoader
 {
     public class MatchingProperties : ScriptableObject
     {
+        [Space(5)] public int baseRarity = 0;
         [Space(5)] public List<StringWithRarity> modNames = new List<StringWithRarity>();
         [Space(5)] public List<StringWithRarity> authorNames = new List<StringWithRarity>();
+
+        [NonSerialized] public PropertyMatcher activePropertyMatcher;
 
         public static MatchingProperties Create(ExtendedContent extendedContent)
         {
             MatchingProperties matchingProperties = ScriptableObject.CreateInstance<MatchingProperties>();
             matchingProperties.name = extendedContent.name + "MatchingProperties";
             return (matchingProperties);
-        }
-
-        internal static bool UpdateRarity(ref int currentValue, int newValue, string debugActionObject = null, string debugActionReason = null)
-        {
-            if (newValue > currentValue)
-            {
-                if (!string.IsNullOrEmpty(debugActionReason))
-                {
-                    if (!string.IsNullOrEmpty(debugActionObject))
-                        DebugHelper.Log("Raised Rarity Of: " + debugActionObject + " From (" + currentValue + ") To (" + newValue + ") Due To Matching " + debugActionReason, DebugType.Developer);
-                    else
-                        DebugHelper.Log("Raised Rarity From (" + currentValue + ") To (" + newValue + ") Due To Matching " + debugActionReason, DebugType.Developer);
-                }
-                currentValue = newValue;
-                return (true);
-            }
-            return (false);
-        }
-
-        internal static int GetHighestRarityViaMatchingWithinRanges(int comparingValue, List<Vector2WithRarity> matchingVectors)
-        {
-            int returnInt = 0;
-            foreach (Vector2WithRarity vectorWithRarity in matchingVectors)
-                if (vectorWithRarity.Rarity >= returnInt)
-                    if ((comparingValue >= vectorWithRarity.Min) && (comparingValue <= vectorWithRarity.Max))
-                        returnInt = vectorWithRarity.Rarity;
-            return (returnInt);
-        }
-
-        internal static int GetHighestRarityViaMatchingNormalizedString(string comparingString, List<StringWithRarity> matchingStrings)
-        {
-            return (GetHighestRarityViaMatchingNormalizedStrings(new List<string>() { comparingString }, matchingStrings));
-        }
-
-        internal static int GetHighestRarityViaMatchingNormalizedTags(List<ContentTag> comparingTags, List<StringWithRarity> matchingStrings)
-        {
-            List<string> contentTagStrings = comparingTags.Select(t => t.contentTagName).ToList();
-            return GetHighestRarityViaMatchingNormalizedStrings(contentTagStrings, matchingStrings);
-        }
-
-        internal static int GetHighestRarityViaMatchingNormalizedStrings(List<string> comparingStrings, List<StringWithRarity> matchingStrings)
-        {
-            int returnInt = 0;
-            foreach (StringWithRarity stringWithRarity in matchingStrings)
-                foreach (string comparingString in new List<string>(comparingStrings))
-                    if (stringWithRarity.Rarity >= returnInt)
-                        if (stringWithRarity.Name.Sanitized().Contains(comparingString.Sanitized()) || comparingString.Sanitized().Contains(stringWithRarity.Name.Sanitized()))
-                            returnInt = stringWithRarity.Rarity;
-            return (returnInt);
         }
     }
 }

--- a/LethalLevelLoader/Components/MatchingProperties/MatchingProperties.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/MatchingProperties.cs
@@ -26,12 +26,23 @@ namespace LethalLevelLoader
             if (_propertyMatcher is not null)
                 return _propertyMatcher;
 
-            _propertyMatcher = propertyMatcherType switch
+            switch (propertyMatcherType)
             {
-                PropertyMatcherType.HighestRarity => new HighestRarityPropertyMatcher(),
-                PropertyMatcherType.Multiplier => new MultiplierPropertyMatcher(),
-                _ => throw new NotImplementedException(
-                    $"Only PropertyMatchers of type {nameof(PropertyMatcherType.HighestRarity)} and {nameof(PropertyMatcherType.Multiplier)} are supported."),
+                case PropertyMatcherType.HighestRarity:
+                    _propertyMatcher = new HighestRarityPropertyMatcher();
+                    break;
+
+                case PropertyMatcherType.Multiplier:
+                    _propertyMatcher = new MultiplierPropertyMatcher();
+                    break;
+
+                default:
+                    DebugHelper.LogWarning(
+                        $"Only PropertyMatchers of type {nameof(PropertyMatcherType.HighestRarity)} and {nameof(PropertyMatcherType.Multiplier)} are supported. " +
+                        $"Continuing by using {nameof(HighestRarityPropertyMatcher)}.",
+                        DebugType.User);
+                    _propertyMatcher = new HighestRarityPropertyMatcher();
+                    break;
             };
 
             return _propertyMatcher;

--- a/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/HighestRarityPropertyMatcher.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/HighestRarityPropertyMatcher.cs
@@ -2,7 +2,7 @@
 
 namespace LethalLevelLoader.Components.MatchingProperties.PropertyMatchers;
 
-public class HighestRarityPropertyMatcher : PropertyMatcher
+internal class HighestRarityPropertyMatcher : PropertyMatcher
 {
     public override bool UpdateRarity(ref int currentValue, int newValue, string debugActionObject = null, string debugActionReason = null)
     {

--- a/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/HighestRarityPropertyMatcher.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/HighestRarityPropertyMatcher.cs
@@ -11,9 +11,9 @@ public class HighestRarityPropertyMatcher : PropertyMatcher
             if (!string.IsNullOrEmpty(debugActionReason))
             {
                 if (!string.IsNullOrEmpty(debugActionObject))
-                    DebugHelper.Log("Raised Rarity Of: " + debugActionObject + " From (" + currentValue + ") To (" + newValue + ") Due To Matching " + debugActionReason, DebugType.Developer);
+                    DebugHelper.Log($"Raised Rarity Of: {debugActionObject} From ({currentValue}) To ({newValue}) Due To Matching {debugActionReason}", DebugType.Developer);
                 else
-                    DebugHelper.Log("Raised Rarity From (" + currentValue + ") To (" + newValue + ") Due To Matching " + debugActionReason, DebugType.Developer);
+                    DebugHelper.Log($"Raised Rarity From ({currentValue}) To ({newValue}) Due To Matching {debugActionReason}", DebugType.Developer);
             }
             currentValue = newValue;
             return true;

--- a/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/HighestRarityPropertyMatcher.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/HighestRarityPropertyMatcher.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+
+namespace LethalLevelLoader.Components.MatchingProperties.PropertyMatchers;
+
+public class HighestRarityPropertyMatcher : PropertyMatcher
+{
+    public override bool UpdateRarity(ref int currentValue, int newValue, string debugActionObject = null, string debugActionReason = null)
+    {
+        if (newValue > currentValue)
+        {
+            if (!string.IsNullOrEmpty(debugActionReason))
+            {
+                if (!string.IsNullOrEmpty(debugActionObject))
+                    DebugHelper.Log("Raised Rarity Of: " + debugActionObject + " From (" + currentValue + ") To (" + newValue + ") Due To Matching " + debugActionReason, DebugType.Developer);
+                else
+                    DebugHelper.Log("Raised Rarity From (" + currentValue + ") To (" + newValue + ") Due To Matching " + debugActionReason, DebugType.Developer);
+            }
+            currentValue = newValue;
+            return true;
+        }
+        return false;
+    }
+
+    public override IEnumerable<int> GetRaritiesViaMatchingWithinRanges(int comparingValue, List<Vector2WithRarity> matchingVectors)
+    {
+        int returnInt = 0;
+        foreach (Vector2WithRarity vectorWithRarity in matchingVectors)
+            if (vectorWithRarity.Rarity >= returnInt)
+                if (comparingValue >= vectorWithRarity.Min && comparingValue <= vectorWithRarity.Max)
+                    returnInt = vectorWithRarity.Rarity;
+        yield return returnInt;
+    }
+
+    public override IEnumerable<int> GetRaritiesViaMatchingNormalizedStrings(List<string> comparingStrings, List<StringWithRarity> matchingStrings)
+    {
+        int returnInt = 0;
+        foreach (StringWithRarity stringWithRarity in matchingStrings)
+            foreach (string comparingString in new List<string>(comparingStrings))
+                if (stringWithRarity.Rarity >= returnInt)
+                    if (stringWithRarity.Name.Sanitized().Contains(comparingString.Sanitized()) || comparingString.Sanitized().Contains(stringWithRarity.Name.Sanitized()))
+                        returnInt = stringWithRarity.Rarity;
+        yield return returnInt;
+    }
+}

--- a/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/MultiplierPropertyMatcher.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/MultiplierPropertyMatcher.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+
+namespace LethalLevelLoader.Components.MatchingProperties.PropertyMatchers;
+
+public class MultiplierPropertyMatcher : PropertyMatcher
+{
+    public override bool UpdateRarity(ref int currentValue, int newValue, string debugActionObject = null, string debugActionReason = null)
+    {
+        int oldValue = currentValue;
+        currentValue *= newValue;
+
+        if (!string.IsNullOrEmpty(debugActionReason))
+        {
+            if (!string.IsNullOrEmpty(debugActionObject))
+                DebugHelper.Log($"Multiplied Rarity Of: {debugActionObject} From ({oldValue}) To ({currentValue}) Due To Matching {debugActionReason}", DebugType.Developer);
+            else
+                DebugHelper.Log($"Multiplied Rarity From ({oldValue}) To ({currentValue}) Due To Matching {debugActionReason}", DebugType.Developer);
+        }
+
+        return true;
+    }
+
+    public override IEnumerable<int> GetRaritiesViaMatchingWithinRanges(int comparingValue, List<Vector2WithRarity> matchingVectors)
+    {
+        foreach (Vector2WithRarity vectorWithRarity in matchingVectors)
+        {
+            if (vectorWithRarity.Min <= comparingValue && comparingValue <= vectorWithRarity.Max)
+                yield return vectorWithRarity.Rarity;
+        }
+
+        yield break;
+    }
+
+    public override IEnumerable<int> GetRaritiesViaMatchingNormalizedStrings(List<string> comparingStrings, List<StringWithRarity> matchingStrings)
+    {
+        foreach (StringWithRarity stringWithRarity in matchingStrings)
+        {
+            foreach (string comparingString in new List<string>(comparingStrings))
+            {
+                if (stringWithRarity.Name.Sanitized().Contains(comparingString.Sanitized()) ||
+                    comparingString.Sanitized().Contains(stringWithRarity.Name.Sanitized()))
+                {
+                    yield return stringWithRarity.Rarity;
+                }
+            }
+        }
+
+        yield break;
+    }
+}

--- a/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/MultiplierPropertyMatcher.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/MultiplierPropertyMatcher.cs
@@ -2,7 +2,7 @@
 
 namespace LethalLevelLoader.Components.MatchingProperties.PropertyMatchers;
 
-public class MultiplierPropertyMatcher : PropertyMatcher
+internal class MultiplierPropertyMatcher : PropertyMatcher
 {
     public override bool UpdateRarity(ref int currentValue, int newValue, string debugActionObject = null, string debugActionReason = null)
     {

--- a/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/PropertyMatcher.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/PropertyMatcher.cs
@@ -9,6 +9,9 @@ namespace LethalLevelLoader.Components.MatchingProperties.PropertyMatchers;
 /// The default property matcher used by LLL is <see cref="HighestRarityPropertyMatcher"/>,<br/>
 /// with <see cref="MultiplierPropertyMatcher"/> as an alternative implementation.
 /// </summary>
+/// <remarks>
+/// Custom PropertyMatchers aren't supported.
+/// </remarks>
 public abstract class PropertyMatcher
 {
     /// <summary>

--- a/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/PropertyMatcher.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/PropertyMatcher.cs
@@ -12,7 +12,7 @@ namespace LethalLevelLoader.Components.MatchingProperties.PropertyMatchers;
 /// <remarks>
 /// Custom PropertyMatchers aren't supported.
 /// </remarks>
-public abstract class PropertyMatcher
+internal abstract class PropertyMatcher
 {
     /// <summary>
     /// Processes updating rarity value using the property matcher's rules.

--- a/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/PropertyMatcher.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/PropertyMatcher.cs
@@ -3,17 +3,47 @@ using System.Linq;
 
 namespace LethalLevelLoader.Components.MatchingProperties.PropertyMatchers;
 
+/// <summary>
+/// A base class for implementing property matchers.<br/>
+/// <br/>
+/// The default property matcher used by LLL is <see cref="HighestRarityPropertyMatcher"/>,<br/>
+/// with <see cref="MultiplierPropertyMatcher"/> as an alternative implementation.
+/// </summary>
 public abstract class PropertyMatcher
 {
+    /// <summary>
+    /// Processes updating rarity value using the property matcher's rules.
+    /// </summary>
+    /// <remarks>
+    /// Called every time a <c>GetRaritiesViaMatching*</c> method of this property matcher yields a value.
+    /// </remarks>
+    /// <param name="currentValue">The value to be modified.</param>
+    /// <param name="newValue">The value yielded by a <c>GetRaritiesViaMatching*</c> method.</param>
+    /// <param name="debugActionObject"></param>
+    /// <param name="debugActionReason"></param>
+    /// <returns><see langword="true"/> if rarity was modified, <see langword="false"/> otherwise.</returns>
     public abstract bool UpdateRarity(ref int currentValue, int newValue, string debugActionObject = null, string debugActionReason = null);
 
+    /// <summary>
+    /// Returns rarities for every match deemed valid by the property matcher.
+    /// </summary>
+    /// <param name="comparingValue">The value we compare against with our matching vectors.</param>
+    /// <param name="matchingVectors">Rarity vectors from an instance of <see cref="LethalLevelLoader.MatchingProperties"/> or a class that inherits it.</param>
+    /// <returns>Every matched rarity, to be processed by this property matcher's implementation of <see cref="UpdateRarity"/>.</returns>
     public abstract IEnumerable<int> GetRaritiesViaMatchingWithinRanges(int comparingValue, List<Vector2WithRarity> matchingVectors);
 
+    /// <param name="comparingStrings">The strings we compare against with our matching strings.</param>
+    /// <param name="matchingStrings">Matching strings from an instance of <see cref="LethalLevelLoader.MatchingProperties"/> or a class that inherits it.</param>
+    /// <inheritdoc cref="GetRaritiesViaMatchingWithinRanges"/>
     public abstract IEnumerable<int> GetRaritiesViaMatchingNormalizedStrings(List<string> comparingStrings, List<StringWithRarity> matchingStrings);
 
+    /// <param name="comparingString">The string we compare against with our matching strings.</param>
+    /// <inheritdoc cref="GetRaritiesViaMatchingNormalizedStrings"/>
     public IEnumerable<int> GetRaritiesViaMatchingNormalizedString(string comparingString, List<StringWithRarity> matchingStrings)
         => GetRaritiesViaMatchingNormalizedStrings([comparingString], matchingStrings);
 
+    /// <param name="comparingTags">The tags we compare against with our matching strings.</param>
+    /// <inheritdoc cref="GetRaritiesViaMatchingNormalizedStrings"/>
     public IEnumerable<int> GetRaritiesViaMatchingNormalizedTags(List<ContentTag> comparingTags, List<StringWithRarity> matchingStrings)
     {
         List<string> contentTagStrings = comparingTags.Select(t => t.contentTagName).ToList();

--- a/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/PropertyMatcher.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/PropertyMatcher.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace LethalLevelLoader.Components.MatchingProperties.PropertyMatchers;
+
+public abstract class PropertyMatcher
+{
+    public abstract bool UpdateRarity(ref int currentValue, int newValue, string debugActionObject = null, string debugActionReason = null);
+
+    public abstract IEnumerable<int> GetRaritiesViaMatchingWithinRanges(int comparingValue, List<Vector2WithRarity> matchingVectors);
+
+    public abstract IEnumerable<int> GetRaritiesViaMatchingNormalizedStrings(List<string> comparingStrings, List<StringWithRarity> matchingStrings);
+
+    public IEnumerable<int> GetRaritiesViaMatchingNormalizedString(string comparingString, List<StringWithRarity> matchingStrings)
+        => GetRaritiesViaMatchingNormalizedStrings([comparingString], matchingStrings);
+
+    public IEnumerable<int> GetRaritiesViaMatchingNormalizedTags(List<ContentTag> comparingTags, List<StringWithRarity> matchingStrings)
+    {
+        List<string> contentTagStrings = comparingTags.Select(t => t.contentTagName).ToList();
+        return GetRaritiesViaMatchingNormalizedStrings(contentTagStrings, matchingStrings);
+    }
+}

--- a/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/PropertyMatcherType.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/PropertyMatchers/PropertyMatcherType.cs
@@ -1,0 +1,7 @@
+﻿namespace LethalLevelLoader.Components.MatchingProperties.PropertyMatchers;
+
+public enum PropertyMatcherType
+{
+    HighestRarity = 0,
+    Multiplier = 1,
+}


### PR DESCRIPTION
I made an (at least proof of concept) implementation for supporting multiple property matching implementations, so we can see if supporting a multiplier based property is actually so problematic that even modders shouldn't have access to this feature (which, this makes the matching by tags feature much more powerful, which the feature is already pretty much the only selling point for enemy modders over LethalLib, which as it currently is, isn't enough for enemy modders to really bother moving to LLL). 

First off, implementation details:
- I made an abstract `PropertyMatcher` class.
    - The methods for matching return `IEnumerable<int>`, meaning they can `yield return` multiple rarities.
        - This is because the multiplier implementation can match multiple things.
    - The `UpdateRarity` method is called for every `yield return`.
        - Again, this is so that the current value can be multiplied by the return value.
    - The default implementation, now called `HighestRarityPropertyMatcher`, is fully compatible with this system.
- To make this configurable from a `ScriptableObject`, I made an Enum `PropertyMatcherType`.
    - It has both the default implementation + the multiplier implementation.
    - When `GetDynamicRarity` is called, `GetPropertyMatcher` gets the property matcher based on the enum value.
- I also added a `baseRarity` to the `MatchingProperties` ScriptableObject.
    - It will be the starting value for any property matcher implementation.
        - This specifically helps with the multiplier implementation.

If this isn't getting to LLL, this is probably going to be implemented into LethalLib with some rewrites to the codebase, or more likely as it currently seems like, we are going to start a new, modular content API project (separated into multiple assemblies for different functions and stuff) from scratch to best suit our needs.

This is currently a draft because I haven't actually checked if this works, but also I would expect some discussion first too before this is even considered.

Edit: I am aware that I'll need to change the scale of the multiplying to be maybe 100 or something as the neutral option, since the rarities are integers and we can't do precise float multiplication around 1.0f (as the neutral option)