### PR TITLE
Fixed ArgumentOutOfRangeException in dungeon flows logging causing game to softlock

### DIFF
--- a/LethalLevelLoader/Patches/DungeonManager.cs
+++ b/LethalLevelLoader/Patches/DungeonManager.cs
@@ -65,7 +65,7 @@ namespace LethalLevelLoader
                 debugString += "Info For ExtendedLevel: " + extendedLevel.name + " | Planet Name: " + extendedLevel.NumberlessPlanetName + " | Content Tags: ";
                 foreach (ContentTag tag in extendedLevel.ContentTags)
                     debugString += tag.contentTagName + ", ";
-                debugString = debugString.Remove(debugString.LastIndexOf(", "));
+                debugString = debugString.TrimEnd([',', ' ']);
                 debugString += " | Route Price: " + extendedLevel.RoutePrice + " | Current Weather: " + extendedLevel.SelectableLevel.currentWeather.ToString();
                 debugString += "\n";
 
@@ -74,7 +74,7 @@ namespace LethalLevelLoader
                 foreach (ExtendedDungeonFlowWithRarity extendedDungeonFlowWithRarity in potentialExtendedDungeonFlowsList)
                     if (!viableDungeonFlows.Contains(extendedDungeonFlowWithRarity.extendedDungeonFlow))
                         debugString += extendedDungeonFlowWithRarity.extendedDungeonFlow.DungeonName + ", ";
-                debugString = debugString.Remove(debugString.LastIndexOf(", "));
+                debugString = debugString.TrimEnd([',', ' ']);
                 debugString += "\n";
 
                 returnExtendedDungeonFlowsList = returnExtendedDungeonFlowsList.OrderBy(e => e.rarity).Reverse().ToList();
@@ -82,7 +82,7 @@ namespace LethalLevelLoader
                 debugString += "Viable ExtendedDungeonFlows: ";
                 foreach (ExtendedDungeonFlowWithRarity extendedDungeonFlowWithRarity in returnExtendedDungeonFlowsList)
                     debugString += extendedDungeonFlowWithRarity.extendedDungeonFlow.DungeonName + " (" + extendedDungeonFlowWithRarity.rarity + ")" + ", ";
-                debugString = debugString.Remove(debugString.LastIndexOf(", "));
+                debugString = debugString.TrimEnd([',', ' ']);
 
                 DebugHelper.Log(debugString + "\n", DebugType.User);
             }


### PR DESCRIPTION
Hi

Wanted to share this quick fix which causes soft-locking for me when loading specific moons (Peter Griffin and Castle Grounds moon to be specific).

On these moons the game can throw this exception and refuse to load further:
```
[22:17:43.6061146] [Error  : Unity Log] ArgumentOutOfRangeException: StartIndex cannot be less than zero.
Parameter name: startIndex
Stack trace:
System.String.Remove (System.Int32 startIndex) (at <787acc3c9a4c471ba7d971300105af24>:IL_0004)
LethalLevelLoader.DungeonManager.GetValidExtendedDungeonFlows (LethalLevelLoader.ExtendedLevel extendedLevel, System.Boolean debugResults) (at ./Patches/DungeonManager.cs:79)
LethalLevelLoader.LethalLevelLoaderNetworkManager.GetRandomExtendedDungeonFlowServerRpc () (at ./Patches/LethalLevelLoaderNetworkManager.cs:49)
LethalLevelLoader.LethalLevelLoaderNetworkManager.__rpc_handler_12573863 (Unity.Netcode.NetworkBehaviour target, Unity.Netcode.FastBufferReader reader, Unity.Netcode.__RpcParams rpcParams) (at <d73e0c1b9b164a729e70bc14c984ea41>:IL_007B)
```

Long story short, the code looks for a ", " inside debugString and can't find it because there are no "Unviable ExtendedDungeonFlows" causing exception.

Fixed it with TrimEnd which shouldn't cause any exceptions if it can't find a ", ".

Also this fixes logging, because sometimes the "Route Price" and "Current Weather" strings were missing.