### PR TITLE
Custom Scrap Control through Configuration

### DIFF
--- a/LethalLevelLoader/General/Content.cs
+++ b/LethalLevelLoader/General/Content.cs
@@ -270,6 +270,11 @@ namespace LethalLevelLoader
                 TryAdd(ExtendedEnemyTypeDictionary, extendedEnemyType.EnemyType, extendedEnemyType);
             foreach (ExtendedBuyableVehicle extendedBuyableVehicle in ExtendedBuyableVehicles)
                 TryAdd(ExtendedBuyableVehicleDictionary, extendedBuyableVehicle.BuyableVehicle, extendedBuyableVehicle);
+
+            foreach(ExtendedItem extendedItem in CustomExtendedItems)
+            {
+                Items.Add(extendedItem.Item);
+            }
         }
 
         internal static void TryAdd<T1,T2>(Dictionary<T1, T2> dict, T1 key, T2 value)

--- a/LethalLevelLoader/General/SafetyPatches.cs
+++ b/LethalLevelLoader/General/SafetyPatches.cs
@@ -92,32 +92,24 @@ namespace LethalLevelLoader
         [HarmonyPrefix]
         internal static bool RoundManagerSpawnScrapInLevel_Prefix()
         {
-            List<SpawnableItemWithRarity> scrapList = LevelManager.CurrentExtendedLevel.SelectableLevel.spawnableScrap;
-
-            DebugHelper.Log("scrap IDs and rarities", DebugType.User);
-            int scrapID = 0;
-            foreach (SpawnableItemWithRarity spawnableScrap in scrapList)
-            {
-                DebugHelper.Log(scrapID + ". " + spawnableScrap.spawnableItem.itemName + " [" + spawnableScrap.spawnableItem.name + "] => " + spawnableScrap.rarity, DebugType.User);
-                scrapID++;
-            }
-
             if (Settings.allowModConfigOverwrite)
             {
-                DebugHelper.Log("allowModConfigOverwrite is enabled - Overloading scrap spawn rarities.", DebugType.User);
+                DebugHelper.Log("allowModConfigOverwrite is enabled - Overloading scrap spawn rarities for " + LevelManager.CurrentExtendedLevel.SelectableLevel.PlanetName + " [" + LevelManager.CurrentExtendedLevel.SelectableLevel.levelID + "].", DebugType.User);
 
-                List<SpawnableItemWithRarity> overrideList = new List<SpawnableItemWithRarity>();
+                String overrideList;
                 if (Settings.scrapOverrides.TryGetValue(LevelManager.CurrentExtendedLevel.SelectableLevel.levelID, out overrideList))
                 {
+                    DebugHelper.Log(overrideList, DebugType.User);
                     DebugHelper.Log("Overload list:", DebugType.User);
+                    List<SpawnableItemWithRarity> overrideScrapList = ConfigHelper.ConvertToSpawnableItemWithRarityList(overrideList, new Vector2(0, 100));
                     int scrapID_test = 0;
-                    foreach (SpawnableItemWithRarity spawnableScrap in overrideList)
+                    foreach (SpawnableItemWithRarity spawnableScrapID2 in overrideScrapList)
                     {
-                        DebugHelper.Log(scrapID_test + ". " + spawnableScrap.spawnableItem.itemName + " [" + spawnableScrap.spawnableItem.name + "] => " + spawnableScrap.rarity, DebugType.User);
+                        DebugHelper.Log(scrapID_test + ". " + spawnableScrapID2.spawnableItem.itemName + " [" + spawnableScrapID2.spawnableItem.name + "] => " + spawnableScrapID2.rarity, DebugType.User);
                         scrapID_test++;
                     }
 
-                    scrapList = overrideList;
+                    LevelManager.CurrentExtendedLevel.SelectableLevel.spawnableScrap = overrideScrapList;
                 }
                 else
                 {
@@ -126,16 +118,16 @@ namespace LethalLevelLoader
             }
 
             List<SpawnableItemWithRarity> invalidSpawnableItemWithRarity = new List<SpawnableItemWithRarity>();
-            foreach (SpawnableItemWithRarity spawnableScrap in scrapList)
+            foreach (SpawnableItemWithRarity spawnableScrap in LevelManager.CurrentExtendedLevel.SelectableLevel.spawnableScrap)
                 if (spawnableScrap.spawnableItem == null || spawnableScrap.rarity == 0)
                     invalidSpawnableItemWithRarity.Add(spawnableScrap);
 
             if (invalidSpawnableItemWithRarity.Count != 0)
                 DebugHelper.LogError("Removed: " + invalidSpawnableItemWithRarity.Count + " SpawnableItemWithRarities From CurrentLevel: " + LevelManager.CurrentExtendedLevel.NumberlessPlanetName + " Due To Invalid Properties To Prevent Errors.", DebugType.User);
             foreach (SpawnableItemWithRarity invalidItem in invalidSpawnableItemWithRarity)
-                scrapList.Remove(invalidItem);
+                LevelManager.CurrentExtendedLevel.SelectableLevel.spawnableScrap.Remove(invalidItem);
 
-            if (scrapList.Count == 0)
+            if (LevelManager.CurrentExtendedLevel.SelectableLevel.spawnableScrap.Count == 0)
             {
                 DebugHelper.LogError("Current ExtendedLevel: " + LevelManager.CurrentExtendedLevel.NumberlessPlanetName + " Requested 0 SpawnableScrap, Returning Early To Prevent Errors", DebugType.User);
                 return (false);

--- a/LethalLevelLoader/General/Settings.cs
+++ b/LethalLevelLoader/General/Settings.cs
@@ -30,10 +30,10 @@ namespace LethalLevelLoader
         }
 
 
-        public static ConcurrentDictionary<int, List<SpawnableItemWithRarity>> scrapOverrides;
-        public static ConcurrentDictionary<int, List<SpawnableEnemyWithRarity>> enemyOverrides;
-        public static ConcurrentDictionary<int, List<SpawnableEnemyWithRarity>> daytimeEnemyOverrides;
-        public static ConcurrentDictionary<int, List<SpawnableEnemyWithRarity>> outdoorEnemyOverrides;
+        public static ConcurrentDictionary<int, String> scrapOverrides = new ConcurrentDictionary<int, String>();
+        public static ConcurrentDictionary<int, String> enemyOverrides = new ConcurrentDictionary<int, String>();
+        public static ConcurrentDictionary<int, String> daytimeEnemyOverrides = new ConcurrentDictionary<int, String>();
+        public static ConcurrentDictionary<int, String> outdoorEnemyOverrides = new ConcurrentDictionary<int, String>();
 
     }
 }

--- a/LethalLevelLoader/General/Settings.cs
+++ b/LethalLevelLoader/General/Settings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Text;
 
 namespace LethalLevelLoader
@@ -19,6 +20,7 @@ namespace LethalLevelLoader
         public static DebugType debugType = DebugType.User;
         public static bool allDungeonFlowsRequireMatching = false;
         public static int moonsCatalogueSplitCount = 3;
+        public static bool allowModConfigOverwrite = false;
 
         public static string GetOverridePreviewInfo(ExtendedLevel extendedLevel)
         {
@@ -26,6 +28,12 @@ namespace LethalLevelLoader
 
             return (returnString);
         }
+
+
+        public static ConcurrentDictionary<int, List<SpawnableItemWithRarity>> scrapOverrides;
+        public static ConcurrentDictionary<int, List<SpawnableEnemyWithRarity>> enemyOverrides;
+        public static ConcurrentDictionary<int, List<SpawnableEnemyWithRarity>> daytimeEnemyOverrides;
+        public static ConcurrentDictionary<int, List<SpawnableEnemyWithRarity>> outdoorEnemyOverrides;
 
     }
 }

--- a/LethalLevelLoader/Tools/ConfigLoader.cs
+++ b/LethalLevelLoader/Tools/ConfigLoader.cs
@@ -83,6 +83,8 @@ namespace LethalLevelLoader.Tools
         private ConfigEntry<int> moonsCatalogueSplitCount;
         private ConfigEntry<bool> requireMatchesOnAllDungeonFlows;
 
+        private ConfigEntry<bool> allowModConfigOverwrite;
+
         public GeneralSettingsConfig(ConfigFile newConfigFile, string newCategory, int newSortingPriority) : base(newConfigFile, newCategory, newSortingPriority) { }
 
         public void BindConfigs()
@@ -98,6 +100,8 @@ namespace LethalLevelLoader.Tools
 
             requireMatchesOnAllDungeonFlows = BindValue("Require Matches On All Possible DungeonFlows", "By default any Dungeons requested by the loading level will skip the matching process and be in the possible selection pool, Set this to false to disable this feature", true);
 
+            allowModConfigOverwrite = BindValue("Overwrite Moon Spawn Rates and Rarities", "Allow LethalLevelLoader Moon configurations to override mod spawn rates and rarities for custom scrap and custom enemies from their respective configuration files.", false);
+
             Settings.debugType = debugTypeToggle.Value;
             Settings.levelPreviewInfoType = previewInfoTypeToggle.Value;
             Settings.levelPreviewSortType = sortInfoTypeToggle.Value;
@@ -108,6 +112,8 @@ namespace LethalLevelLoader.Tools
                 Settings.moonsCatalogueSplitCount = moonsCatalogueSplitCount.Value;
 
             Settings.allDungeonFlowsRequireMatching = requireMatchesOnAllDungeonFlows.Value;
+
+            Settings.allowModConfigOverwrite = allowModConfigOverwrite.Value;
         }
     }
 
@@ -293,10 +299,15 @@ namespace LethalLevelLoader.Tools
                     selectableLevel.maxOutsideEnemyPowerCount = maxOutsideNighttimeEnemyPowerCount.Value;
 
                     selectableLevel.Enemies = ConfigHelper.ConvertToSpawnableEnemyWithRarityList(insideEnemiesOverrides.Value, new Vector2(0, 100));
-                    selectableLevel.DaytimeEnemies = ConfigHelper.ConvertToSpawnableEnemyWithRarityList(outsideDaytimeEnemiesOverrides.Value, new Vector2(0, 100));
+                    selectableLevel.DaytimeEnemies = ConfigHelper.ConvertToSpawnableEnemyWithRarityList(outsideDaytimeEnemiesOverrides.Value, new Vector2(0, 100)); ;
                     selectableLevel.OutsideEnemies = ConfigHelper.ConvertToSpawnableEnemyWithRarityList(outsideNighttimeEnemiesOverrides.Value, new Vector2(0, 100));
 
                     ConfigLoader.debugLevelsString += selectableLevel.PlanetName + ", ";
+
+                    Settings.scrapOverrides.TryAdd(selectableLevel.levelID, ConfigHelper.ConvertToSpawnableItemWithRarityList(scrapOverrides.Value, new Vector2(0, 100)));
+                    Settings.enemyOverrides.TryAdd(selectableLevel.levelID, ConfigHelper.ConvertToSpawnableEnemyWithRarityList(insideEnemiesOverrides.Value, new Vector2(0, 100)));
+                    Settings.daytimeEnemyOverrides.TryAdd(selectableLevel.levelID, ConfigHelper.ConvertToSpawnableEnemyWithRarityList(outsideDaytimeEnemiesOverrides.Value, new Vector2(0, 100)));
+                    Settings.outdoorEnemyOverrides.TryAdd(selectableLevel.levelID, ConfigHelper.ConvertToSpawnableEnemyWithRarityList(outsideNighttimeEnemiesOverrides.Value, new Vector2(0, 100)));
                 }
             }
             else

--- a/LethalLevelLoader/Tools/ConfigLoader.cs
+++ b/LethalLevelLoader/Tools/ConfigLoader.cs
@@ -304,10 +304,10 @@ namespace LethalLevelLoader.Tools
 
                     ConfigLoader.debugLevelsString += selectableLevel.PlanetName + ", ";
 
-                    Settings.scrapOverrides.TryAdd(selectableLevel.levelID, ConfigHelper.ConvertToSpawnableItemWithRarityList(scrapOverrides.Value, new Vector2(0, 100)));
-                    Settings.enemyOverrides.TryAdd(selectableLevel.levelID, ConfigHelper.ConvertToSpawnableEnemyWithRarityList(insideEnemiesOverrides.Value, new Vector2(0, 100)));
-                    Settings.daytimeEnemyOverrides.TryAdd(selectableLevel.levelID, ConfigHelper.ConvertToSpawnableEnemyWithRarityList(outsideDaytimeEnemiesOverrides.Value, new Vector2(0, 100)));
-                    Settings.outdoorEnemyOverrides.TryAdd(selectableLevel.levelID, ConfigHelper.ConvertToSpawnableEnemyWithRarityList(outsideNighttimeEnemiesOverrides.Value, new Vector2(0, 100)));
+                    Settings.scrapOverrides.TryAdd(selectableLevel.levelID, scrapOverrides.Value);
+                    Settings.enemyOverrides.TryAdd(selectableLevel.levelID, insideEnemiesOverrides.Value);
+                    Settings.daytimeEnemyOverrides.TryAdd(selectableLevel.levelID, outsideDaytimeEnemiesOverrides.Value);
+                    Settings.outdoorEnemyOverrides.TryAdd(selectableLevel.levelID, outsideNighttimeEnemiesOverrides.Value);
                 }
             }
             else


### PR DESCRIPTION
This PR adds in blocks of code that allows the mod's configuration file to properly apply modded scrap weights to moons, it also adds the required first bit of code to do the same with custom enemies (Although this PR does not handle custom enemies).