### PR TITLE
[EXPERIMENTAL BRANCH] Fixed NullReferenceException issue with SaveAllLevels()

### DIFF
--- a/LethalLevelLoader/Components/LLLSaveFile.cs
+++ b/LethalLevelLoader/Components/LLLSaveFile.cs
@@ -12,8 +12,8 @@ namespace LethalLevelLoader
         public string CurrentLevelName { get; internal set; } = string.Empty;
 
         public int parityStepsTaken;
-        public Dictionary<int, AllItemsListItemData> itemSaveData = new Dictionary<int, AllItemsListItemData>();
-        public List<ExtendedLevelData> extendedLevelSaveData = new List<ExtendedLevelData>();
+        public Dictionary<int, AllItemsListItemData> itemSaveData = [];
+        public List<ExtendedLevelData> extendedLevelSaveData = [];
 
         public LLLSaveFile()
         {
@@ -24,8 +24,8 @@ namespace LethalLevelLoader
         {
             CurrentLevelName = string.Empty;
             parityStepsTaken = 0;
-            itemSaveData = new Dictionary<int, AllItemsListItemData>();
-            extendedLevelSaveData = new List<ExtendedLevelData>();
+            itemSaveData.Clear();
+            extendedLevelSaveData.Clear();
         }
     }
 

--- a/LethalLevelLoader/Patches/SaveManager.cs
+++ b/LethalLevelLoader/Patches/SaveManager.cs
@@ -50,6 +50,17 @@ namespace LethalLevelLoader
                 foreach (ExtendedLevelData extendedLevelData in currentSaveFile.extendedLevelSaveData)
                     LethalLevelLoaderNetworkManager.Instance.SetExtendedLevelValuesServerRpc(extendedLevelData);
             }
+            else
+            {
+                // currentSaveFile.Load() makes collections null if not present
+                currentSaveFile.extendedLevelSaveData = [];
+            }
+
+            if (currentSaveFile.itemSaveData == null)
+            {
+                // currentSaveFile.Load() makes collections null if not present
+                currentSaveFile.itemSaveData = [];
+            }
         }
 
         internal static void SaveGameValues()


### PR DESCRIPTION
Due to ``currentSaveFile.Load()`` method call would make any collection present in the ``ModDataContainer`` derived class null'ed, a NRE would be thrown when attempting to save all levels into this derived class.

So we just make sure the collections are not null to ensure correctness in the functions that utilize these collections rather than constantly having null checks every time we manipulate these collections.