### PR TITLE
set lockedNode acceptAnything property to false

### DIFF
--- a/LethalLevelLoader/Patches/TerminalManager.cs
+++ b/LethalLevelLoader/Patches/TerminalManager.cs
@@ -76,6 +76,7 @@ namespace LethalLevelLoader
             lockedNode = CreateNewTerminalNode();
             lockedNode.name = "lockedLevelNode";
             lockedNode.clearPreviousText = true;
+            lockedNode.acceptAnything = false;
         }
 
         internal static bool OnBeforeRouteNodeLoaded(ref TerminalNode currentNode, ref TerminalNode loadNode)


### PR DESCRIPTION
fix common issue where trying to route to a locked moon would lock the terminal until you left the terminal and entered it again (throwing "Index was outside the bounds of array" error)

``acceptAnything`` being set to true must have at least one compatible noun in the ``terminalOptions`` property array or you will always encounter this issue. Since the locked node should not have any compatible nouns you can just set ``acceptAnything`` to false.