### PR TITLE
Fixes/Refactoring

### DIFF
--- a/LethalLevelLoader/AssetBundles/AssetBundleLoader.cs
+++ b/LethalLevelLoader/AssetBundles/AssetBundleLoader.cs
@@ -63,12 +63,10 @@ namespace LethalLevelLoader.AssetBundles
             }
 
             //TODO: Should cache this
-            int foundFilesCount = 0;
             if (directory == null) directory = pluginsFolder;
             if (specifiedFileExtension == null) specifiedFileExtension = ".*";
             if (specifiedFileName == null) specifiedFileName = "*";
-            foreach (string filePath in Directory.GetFiles(directory.FullName, specifiedFileName + specifiedFileExtension, SearchOption.AllDirectories))
-                foundFilesCount++;
+            int foundFilesCount = Directory.GetFiles(directory.FullName, specifiedFileName + specifiedFileExtension, SearchOption.AllDirectories).Length;
 
             if (foundFilesCount == 0)
             {

--- a/LethalLevelLoader/AssetBundles/AssetBundleLoader.cs
+++ b/LethalLevelLoader/AssetBundles/AssetBundleLoader.cs
@@ -66,15 +66,15 @@ namespace LethalLevelLoader.AssetBundles
             if (directory == null) directory = pluginsFolder;
             if (specifiedFileExtension == null) specifiedFileExtension = ".*";
             if (specifiedFileName == null) specifiedFileName = "*";
-            int foundFilesCount = Directory.GetFiles(directory.FullName, specifiedFileName + specifiedFileExtension, SearchOption.AllDirectories).Length;
+            string[] foundFiles = Directory.GetFiles(directory.FullName, specifiedFileName + specifiedFileExtension, SearchOption.AllDirectories);
 
-            if (foundFilesCount == 0)
+            if (foundFiles.Length == 0)
             {
                 DebugHelper.Log("No Files Found, Cancelling LoadAllBundlesRequest!", DebugType.User);
                 return (false);
             }
 
-            LoadAllBundles(directory, specifiedFileName, specifiedFileExtension, onProcessedCallback);
+            LoadAllBundles(directory, specifiedFileName, specifiedFileExtension, onProcessedCallback, foundFiles);
             return (true);
         }
 
@@ -93,7 +93,7 @@ namespace LethalLevelLoader.AssetBundles
             Instance.StartCoroutine(Instance.ClearCacheRoutine());
         }
 
-        private static void LoadAllBundles(DirectoryInfo directory = null, string specifiedFileName = null, string specifiedFileExtension = null, ParameterEvent<AssetBundleGroup> onProcessedCallback = null)
+        private static void LoadAllBundles(DirectoryInfo directory = null, string specifiedFileName = null, string specifiedFileExtension = null, ParameterEvent<AssetBundleGroup> onProcessedCallback = null, string[] foundFiles = default)
         {
 
             AllowLoading = false;
@@ -115,7 +115,7 @@ namespace LethalLevelLoader.AssetBundles
                     processedCallbacksDict.Add((directory.FullName, callBack), new List<ParameterEvent<AssetBundleGroup>>() { onProcessedCallback });
             }
 
-            foreach (string filePath in Directory.GetFiles(directory.FullName, specifiedFileName + specifiedFileExtension, SearchOption.AllDirectories))
+            foreach (string filePath in foundFiles)
             {
                 requestedBundleCount++;
                 AssetBundleInfo newInfo = new AssetBundleInfo(Instance, filePath);

--- a/LethalLevelLoader/AssetBundles/AssetBundleLoader.cs
+++ b/LethalLevelLoader/AssetBundles/AssetBundleLoader.cs
@@ -226,9 +226,12 @@ namespace LethalLevelLoader.AssetBundles
                         foreach (AssetBundleInfo info in newGroup.GetAssetBundleInfos())
                         {
                             if (info.AssetBundleFilePath.Contains(kvp.Key.Item1) && info.AssetBundleFileName.Contains(kvp.Key.Item2))
+                            {
                                 foreach (ParameterEvent<AssetBundleGroup> groupEvent in kvp.Value)
                                     groupEvent.Invoke(newGroup);
-                            break;
+
+                                break;
+                            }
                         }
 
                     List<AssetBundle> allLoadedBundles = new List<AssetBundle>(AssetBundle.GetAllLoadedAssetBundles());

--- a/LethalLevelLoader/AssetBundles/LethalBundleManager.cs
+++ b/LethalLevelLoader/AssetBundles/LethalBundleManager.cs
@@ -87,16 +87,19 @@ namespace LethalLevelLoader
             ExtendedMod matchingExtendedMod = null;
             foreach (ExtendedMod registeredExtendedMod in obtainedExtendedModsList)
             {
-                if (extendedMod.ModMergeSetting == ModMergeSetting.MatchingModName && registeredExtendedMod.ModMergeSetting == ModMergeSetting.MatchingModName)
+                if (extendedMod.ModMergeSetting != registeredExtendedMod.ModMergeSetting) continue;
+
+                bool matched;
+                switch(extendedMod.ModMergeSetting)
                 {
-                    if (registeredExtendedMod.ModName == extendedMod.ModName)
-                        matchingExtendedMod = registeredExtendedMod;
+                    case ModMergeSetting.MatchingModName: matched = extendedMod.ModName == registeredExtendedMod.ModName; break;
+                    case ModMergeSetting.MatchingAuthorName: matched = extendedMod.AuthorName == registeredExtendedMod.AuthorName; break;
+                    default: matched = false; break;
                 }
-                else if (extendedMod.ModMergeSetting == ModMergeSetting.MatchingAuthorName && registeredExtendedMod.ModMergeSetting == ModMergeSetting.MatchingAuthorName)
-                {
-                    if (registeredExtendedMod.AuthorName == extendedMod.AuthorName)
-                        matchingExtendedMod = registeredExtendedMod;
-                }
+                if (!matched) continue;
+
+                matchingExtendedMod = registeredExtendedMod;
+                break;
             }
 
             if (matchingExtendedMod != null)

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedBuyableVehicle.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedBuyableVehicle.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace LethalLevelLoader
 {
@@ -24,6 +21,12 @@ namespace LethalLevelLoader
             newExtendedBuyableVehicle.BuyableVehicle = newBuyableVehicle;
 
             return (newExtendedBuyableVehicle);
+        }
+
+        internal override void Register(ExtendedMod extendedMod)
+        {
+            base.Register(extendedMod);
+            extendedMod.ExtendedBuyableVehicles.Add(this);
         }
     }
 }

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedContent.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedContent.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
 namespace LethalLevelLoader
@@ -22,6 +20,19 @@ namespace LethalLevelLoader
         internal virtual void TryCreateMatchingProperties()
         {
 
+        }
+
+        internal virtual void Register(ExtendedMod extendedMod)
+        {
+            extendedMod.TryThrowInvalidContentException(this, Validators.VerbValidateExtendedContent(this));
+
+            ContentTags.Add(ContentTag.Create("Custom"));
+            ExtendedMod = extendedMod;
+        }
+
+        internal virtual void Unregister(ExtendedMod extendedMod)
+        {
+            ExtendedMod = null;
         }
 
         public bool TryGetTag(string tag)

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedDungeonFlow.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedDungeonFlow.cs
@@ -1,13 +1,9 @@
 ﻿using DunGen.Graph;
 using GameNetcodeStuff;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using UnityEngine;
-using UnityEngine.SceneManagement;
-using static LethalLevelLoader.DungeonEvents;
 
 namespace LethalLevelLoader
 {
@@ -102,12 +98,21 @@ namespace LethalLevelLoader
 
         private void GetDungeonFlowID()
         {
-            if (ContentType == ContentType.Custom)
-                DungeonID = PatchedContent.ExtendedDungeonFlows.Count;
-            if (ContentType == ContentType.Vanilla)
-                foreach (IndoorMapType indoorMapType in Patches.RoundManager.dungeonFlowTypes)
-                    if (indoorMapType.dungeonFlow == DungeonFlow)
-                        DungeonID = Patches.RoundManager.dungeonFlowTypes.ToList().IndexOf(indoorMapType);
+            switch(ContentType)
+            {
+                case ContentType.Custom: DungeonID = PatchedContent.ExtendedDungeonFlows.Count; break;
+                case ContentType.Vanilla:
+                default:
+                    {
+                        foreach (IndoorMapType indoorMapType in Patches.RoundManager.dungeonFlowTypes)
+                        {
+                            if (indoorMapType.dungeonFlow != DungeonFlow) continue;
+                            DungeonID = Patches.RoundManager.dungeonFlowTypes.ToList().IndexOf(indoorMapType);
+                            break;
+                        }
+                        break;
+                    }
+            }
         }
 
         internal override void TryCreateMatchingProperties()
@@ -161,6 +166,20 @@ namespace LethalLevelLoader
                 DebugHelper.LogWarning("ExtendedDungeonFlow.generateAutomaticConfigurationOptions Is Obsolete and will be removed in following releases, Please use ExtendedDungeonFlow.GenerateAutomaticConfigurationOptions instead.", DebugType.Developer);
                 GenerateAutomaticConfigurationOptions = generateAutomaticConfigurationOptions;
             }
+        }
+
+        internal override void Register(ExtendedMod extendedMod)
+        {
+            ConvertObsoleteValues();
+            base.Register(extendedMod);
+
+            extendedMod.ExtendedDungeonFlows.Add(this);
+        }
+
+        internal override void Unregister(ExtendedMod extendedMod)
+        {
+            base.Unregister(extendedMod);
+            extendedMod.ExtendedDungeonFlows.Remove(this);
         }
     }
 

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedEnemyType.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedEnemyType.cs
@@ -36,7 +36,7 @@ namespace LethalLevelLoader
             extendedEnemyType.EnemyType = enemyType;
             extendedEnemyType.name = enemyType.enemyName.SkipToLetters().RemoveWhitespace() + "ExtendedEnemyType";
             extendedEnemyType.ContentType = contentType;
-            extendedMod.RegisterExtendedContent(extendedEnemyType);
+            extendedEnemyType.Register(extendedMod);
 
             extendedEnemyType.TryCreateMatchingProperties();
 
@@ -60,6 +60,13 @@ namespace LethalLevelLoader
                 OutsideLevelMatchingProperties = LevelMatchingProperties.Create(this);
             if (DaytimeLevelMatchingProperties == null)
                 DaytimeLevelMatchingProperties = LevelMatchingProperties.Create(this);
+        }
+
+        internal override void Register(ExtendedMod extendedMod)
+        {
+            base.Register(extendedMod);
+
+            extendedMod.ExtendedEnemyTypes.Add(this);
         }
     }
 }

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedFootstepSurface.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedFootstepSurface.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using UnityEngine;
 
 namespace LethalLevelLoader;
@@ -10,4 +8,11 @@ public class ExtendedFootstepSurface : ExtendedContent
 {
     public FootstepSurface footstepSurface;
     public List<Material> associatedMaterials;
+
+    internal override void Register(ExtendedMod extendedMod)
+    {
+        base.Register(extendedMod);
+
+        extendedMod.ExtendedFootstepSurfaces.Add(this);
+    }
 }

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedItem.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedItem.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace LethalLevelLoader
 {
@@ -66,7 +63,7 @@ namespace LethalLevelLoader
             extendedItem.Item = newItem;
             extendedItem.name = newItem.itemName.SkipToLetters().RemoveWhitespace() + "ExtendedItem";
             extendedItem.ContentType = contentType;
-            extendedMod.RegisterExtendedContent(extendedItem);
+            extendedItem.Register(extendedMod);
 
             extendedItem.TryCreateMatchingProperties();
 
@@ -97,6 +94,20 @@ namespace LethalLevelLoader
             if (Plugin.Instance != null)
                 Debug.LogError("SetLevelMatchingProperties() Should Only Be Used In Editor!");
             LevelMatchingProperties = newLevelMatchingProperties;
+        }
+
+        internal override void Register(ExtendedMod extendedMod)
+        {
+            base.Register(extendedMod);
+
+            extendedMod.ExtendedItems.Add(this);
+        }
+
+        internal override void Unregister(ExtendedMod extendedMod)
+        {
+            base.Unregister(extendedMod);
+
+            extendedMod.ExtendedItems.Remove(this);
         }
     }
 }

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedLevel.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedLevel.cs
@@ -155,22 +155,23 @@ namespace LethalLevelLoader
             if (OverrideQuicksandPrefab == null)
                 OverrideQuicksandPrefab = LevelLoader.defaultQuicksandPrefab;
 
-            if (ContentType == ContentType.Custom)
+            switch(ContentType)
             {
-                name = NumberlessPlanetName.StripSpecialCharacters() + "ExtendedLevel";
-                SelectableLevel.name = NumberlessPlanetName.StripSpecialCharacters() + "Level";
-                if (generateTerminalAssets == true) //Needs to be after levelID setting above.
-                {
-                    //DebugHelper.Log("Generating Terminal Assets For: " + NumberlessPlanetName);
-                    TerminalManager.CreateLevelTerminalData(this, routePrice);
-                }
+                case ContentType.Custom:
+                    {
+                        name = NumberlessPlanetName.StripSpecialCharacters() + "ExtendedLevel";
+                        SelectableLevel.name = NumberlessPlanetName.StripSpecialCharacters() + "Level";
+                        if (generateTerminalAssets == true) //Needs to be after levelID setting above.
+                        {
+                            //DebugHelper.Log("Generating Terminal Assets For: " + NumberlessPlanetName);
+                            TerminalManager.CreateLevelTerminalData(this, routePrice);
+                        }
+                        break;
+                    }
+                case ContentType.Vanilla:
+                default: GetVanillaInfoNode(); break;
             }
-
-            if (ContentType == ContentType.Vanilla)
-                GetVanillaInfoNode();
             SetExtendedDungeonFlowMatches();
-
-            //Obsolete
         }
 
         internal void ConvertObsoleteValues()
@@ -242,6 +243,20 @@ namespace LethalLevelLoader
             if (Plugin.Instance != null)
                 Debug.LogWarning("ForceSetRoutePrice Should Only Be Used In Editor! Consider Using RoutePrice Property To Sync TerminalNode's With New Value.");
             routePrice = newValue;
+        }
+
+        internal override void Register(ExtendedMod extendedMod)
+        {
+            ConvertObsoleteValues();
+            base.Register(extendedMod);
+
+            extendedMod.ExtendedLevels.Add(this);
+        }
+
+        internal override void Unregister(ExtendedMod extendedMod)
+        {
+            base.Unregister(extendedMod);
+            extendedMod.ExtendedLevels.Remove(this);
         }
     }
         

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedMod.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedMod.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
 namespace LethalLevelLoader
@@ -70,7 +68,7 @@ namespace LethalLevelLoader
 
         internal static ExtendedMod Create(string modName)
         {
-            ExtendedMod newExtendedMod = ScriptableObject.CreateInstance<ExtendedMod>();
+            ExtendedMod newExtendedMod = CreateInstance<ExtendedMod>();
             newExtendedMod.ModName = modName;
             newExtendedMod.name = modName.Sanitized() + "Mod";
             DebugHelper.Log("Created New ExtendedMod: " + newExtendedMod.ModName, DebugType.Developer);
@@ -79,7 +77,7 @@ namespace LethalLevelLoader
 
         public static ExtendedMod Create(string modName, string authorName)
         {
-            ExtendedMod newExtendedMod = ScriptableObject.CreateInstance<ExtendedMod>();
+            ExtendedMod newExtendedMod = CreateInstance<ExtendedMod>();
             newExtendedMod.ModName = modName;
             newExtendedMod.name = modName.SkipToLetters().RemoveWhitespace() + "Mod";
             newExtendedMod.AuthorName = authorName;
@@ -90,7 +88,7 @@ namespace LethalLevelLoader
 
         public static ExtendedMod Create(string modName, string authorName, ExtendedContent[] extendedContents)
         {
-            ExtendedMod newExtendedMod = ScriptableObject.CreateInstance<ExtendedMod>();
+            ExtendedMod newExtendedMod = CreateInstance<ExtendedMod>();
             newExtendedMod.ModName = modName;
             newExtendedMod.name = modName.SkipToLetters().RemoveWhitespace() + "Mod";
             newExtendedMod.AuthorName = authorName;
@@ -110,24 +108,7 @@ namespace LethalLevelLoader
             {
                 if (!ExtendedContents.Contains(newExtendedContent))
                 {
-                    if (newExtendedContent is ExtendedLevel extendedLevel)
-                        RegisterExtendedContent(extendedLevel);
-                    else if (newExtendedContent is ExtendedDungeonFlow extendedDungeonFlow)
-                        RegisterExtendedContent(extendedDungeonFlow);
-                    else if (newExtendedContent is ExtendedItem extendedItem)
-                        RegisterExtendedContent(extendedItem);
-                    else if (newExtendedContent is ExtendedEnemyType extendedEnemyType)
-                        RegisterExtendedContent(extendedEnemyType);
-                    else if (newExtendedContent is ExtendedWeatherEffect extendedWeatherEffect)
-                        RegisterExtendedContent(extendedWeatherEffect);
-                    else if (newExtendedContent is ExtendedFootstepSurface extendedFootstepSurface)
-                        RegisterExtendedContent(extendedFootstepSurface);
-                    else if (newExtendedContent is ExtendedStoryLog extendedStoryLog)
-                        RegisterExtendedContent(extendedStoryLog);
-                    else if (newExtendedContent is ExtendedBuyableVehicle extendedBuyableVehicle)
-                        RegisterExtendedContent(extendedBuyableVehicle);
-                    else
-                        throw new ArgumentException(nameof(newExtendedContent), newExtendedContent.name + " (" + newExtendedContent.GetType().Name + ") " + " Could Not Be Registered To ExtendedMod: " + ModName + " Due To Unimplemented Registration Check!");
+                    newExtendedContent.Register(this);
                 }
                 else
                     throw new ArgumentException(nameof(newExtendedContent), newExtendedContent.name + " (" + newExtendedContent.GetType().Name + ") " + " Could Not Be Registered To ExtendedMod: " + ModName + " Due To Already Being Registered To This Mod!");
@@ -135,81 +116,6 @@ namespace LethalLevelLoader
             else
                 throw new ArgumentNullException(nameof(newExtendedContent), "Null ExtendedContent Could Not Be Registered To ExtendedMod: " + ModName + " Due To Failed Validation Check!");
         }
-
-        internal void RegisterExtendedContent(ExtendedLevel extendedLevel)
-        {
-            extendedLevel.ConvertObsoleteValues();
-            TryThrowInvalidContentException(extendedLevel, Validators.ValidateExtendedContent(extendedLevel));
-
-            ExtendedLevels.Add(extendedLevel);
-            extendedLevel.ContentTags.Add(ContentTag.Create("Custom"));
-            extendedLevel.ExtendedMod = this;
-        }
-
-        internal void RegisterExtendedContent(ExtendedDungeonFlow extendedDungeonFlow)
-        {
-            extendedDungeonFlow.ConvertObsoleteValues();
-            TryThrowInvalidContentException(extendedDungeonFlow, Validators.ValidateExtendedContent(extendedDungeonFlow));
-
-            ExtendedDungeonFlows.Add(extendedDungeonFlow);
-            extendedDungeonFlow.ContentTags.Add(ContentTag.Create("Custom"));
-            extendedDungeonFlow.ExtendedMod = this;
-        }
-
-        internal void RegisterExtendedContent(ExtendedItem extendedItem)
-        {
-            TryThrowInvalidContentException(extendedItem, Validators.ValidateExtendedContent(extendedItem));
-
-            ExtendedItems.Add(extendedItem);
-            extendedItem.ContentTags.Add(ContentTag.Create("Custom"));
-            extendedItem.ExtendedMod = this;
-        }
-
-        internal void RegisterExtendedContent(ExtendedEnemyType extendedEnemyType)
-        {
-            TryThrowInvalidContentException(extendedEnemyType, Validators.ValidateExtendedContent(extendedEnemyType));
-
-            ExtendedEnemyTypes.Add(extendedEnemyType);
-            extendedEnemyType.ContentTags.Add(ContentTag.Create("Custom"));
-            extendedEnemyType.ExtendedMod = this;
-        }
-
-        internal void RegisterExtendedContent(ExtendedWeatherEffect extendedWeatherEffect)
-        {
-            TryThrowInvalidContentException(extendedWeatherEffect, Validators.ValidateExtendedContent(extendedWeatherEffect));
-
-            ExtendedWeatherEffects.Add(extendedWeatherEffect);
-            extendedWeatherEffect.ContentTags.Add(ContentTag.Create("Custom"));
-            extendedWeatherEffect.ExtendedMod = this;
-        }
-
-        internal void RegisterExtendedContent(ExtendedFootstepSurface extendedFootstepSurface)
-        {
-            TryThrowInvalidContentException(extendedFootstepSurface, Validators.ValidateExtendedContent(extendedFootstepSurface));
-
-            ExtendedFootstepSurfaces.Add(extendedFootstepSurface);
-            extendedFootstepSurface.ContentTags.Add(ContentTag.Create("Custom"));
-            extendedFootstepSurface.ExtendedMod = this;
-        }
-
-        internal void RegisterExtendedContent(ExtendedStoryLog extendedStoryLog)
-        {
-            TryThrowInvalidContentException(extendedStoryLog, Validators.ValidateExtendedContent(extendedStoryLog));
-
-            ExtendedStoryLogs.Add(extendedStoryLog);
-            extendedStoryLog.ContentTags.Add(ContentTag.Create("Custom"));
-            extendedStoryLog.ExtendedMod = this;
-        }
-
-        internal void RegisterExtendedContent(ExtendedBuyableVehicle extendedBuyableVehicle)
-        {
-            TryThrowInvalidContentException(extendedBuyableVehicle, Validators.ValidateExtendedContent(extendedBuyableVehicle));
-
-            ExtendedBuyableVehicles.Add(extendedBuyableVehicle);
-            extendedBuyableVehicle.ContentTags.Add(ContentTag.Create("Custom"));
-            extendedBuyableVehicle.ExtendedMod = this;
-        }
-
         internal void TryThrowInvalidContentException(ExtendedContent extendedContent, (bool,string) result)
         {
             if (result.Item1 == false)
@@ -223,14 +129,7 @@ namespace LethalLevelLoader
 
         internal void UnregisterExtendedContent(ExtendedContent currentExtendedContent)
         {
-            if (currentExtendedContent is ExtendedLevel extendedLevel)
-                ExtendedLevels.Remove(extendedLevel);
-            else if (currentExtendedContent is ExtendedDungeonFlow extendedDungeonFlow)
-                ExtendedDungeonFlows.Remove(extendedDungeonFlow);
-            else if (currentExtendedContent is ExtendedItem extendedItem)
-                ExtendedItems.Remove(extendedItem);
-
-            currentExtendedContent.ExtendedMod = null;
+            currentExtendedContent.Unregister(this);
             DebugHelper.LogWarning("Unregistered ExtendedContent: " + currentExtendedContent.name + " In ExtendedMod: " + ModName, DebugType.Developer);
         }
 

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedStoryLog.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedStoryLog.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace LethalLevelLoader
 {
@@ -18,5 +15,12 @@ namespace LethalLevelLoader
         [TextArea] public string storyLogDescription = string.Empty;
 
         [HideInInspector] internal int newStoryLogID;
+
+        internal override void Register(ExtendedMod extendedMod)
+        {
+            base.Register(extendedMod);
+
+            extendedMod.ExtendedStoryLogs.Add(this);
+        }
     }
 }

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedWeatherEffect.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedWeatherEffect.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace LethalLevelLoader
 {
@@ -42,6 +38,13 @@ namespace LethalLevelLoader
             newExtendedWeatherEffect.GlobalObject = globalObject;
 
             return (newExtendedWeatherEffect);
+        }
+
+        internal override void Register(ExtendedMod extendedMod)
+        {
+            base.Register(extendedMod);
+
+            extendedMod.ExtendedWeatherEffects.Add(this);
         }
     }
 }

--- a/LethalLevelLoader/Components/MatchingProperties/DungeonMatchingProperties.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/DungeonMatchingProperties.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace LethalLevelLoader
 {
     [CreateAssetMenu(fileName = "DungeonMatchingProperties", menuName = "Lethal Level Loader/Utility/DungeonMatchingProperties", order = 13)]
-    public class DungeonMatchingProperties : MatchingProperties
+    public class DungeonMatchingProperties : MatchingProperties<ExtendedDungeonFlow>
     {
         [Space(5)] public List<StringWithRarity> dungeonTags = new List<StringWithRarity>();
         [Space(5)] public List<StringWithRarity> dungeonNames = new List<StringWithRarity>();
@@ -17,13 +17,11 @@ namespace LethalLevelLoader
             dungeonMatchingProperties.name = extendedContent.name + "DungeonMatchingProperties";
             return (dungeonMatchingProperties);
         }
-        public int GetDynamicRarity(ExtendedDungeonFlow extendedDungeonFlow)
+        internal override int GetDynamicRarity(ExtendedDungeonFlow extendedDungeonFlow)
         {
-            int returnRarity = 0;
+            int returnRarity = base.GetDynamicRarity(extendedDungeonFlow);
 
             UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedTags(extendedDungeonFlow.ContentTags, dungeonNames), extendedDungeonFlow.name, "Content Tags");
-            UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedString(extendedDungeonFlow.AuthorName, authorNames), extendedDungeonFlow.name, "Author Name");
-            UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedStrings(extendedDungeonFlow.ExtendedMod.ModNameAliases, modNames), extendedDungeonFlow.name, "Mod Name Name");
             UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedString(extendedDungeonFlow.DungeonFlow.name, dungeonNames), extendedDungeonFlow.name, "Dungeon Name");
 
             return (returnRarity);

--- a/LethalLevelLoader/Components/MatchingProperties/LevelMatchingProperties.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/LevelMatchingProperties.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using UnityEngine;
 
 namespace LethalLevelLoader
 {
     [CreateAssetMenu(fileName = "LevelMatchingProperties", menuName = "Lethal Level Loader/Utility/LevelMatchingProperties", order = 12)]
-    public class LevelMatchingProperties : MatchingProperties
+    public class LevelMatchingProperties : MatchingProperties<ExtendedLevel>
     {
         [Space(5)] public List<StringWithRarity> levelTags = new List<StringWithRarity>();
         [Space(5)] public List<Vector2WithRarity> currentRoutePrice = new List<Vector2WithRarity>();
@@ -20,17 +18,14 @@ namespace LethalLevelLoader
             return (levelMatchingProperties);
         }
 
-        public int GetDynamicRarity(ExtendedLevel extendedLevel)
+        internal override int GetDynamicRarity(ExtendedLevel extendedLevel)
         {
-            int returnRarity = 0;
+            int returnRarity = base.GetDynamicRarity(extendedLevel);
 
             UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedTags(extendedLevel.ContentTags, levelTags), extendedLevel.name, "Content Tags");
-            UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedString(extendedLevel.AuthorName, authorNames), extendedLevel.name, "Author Name");
-            UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedStrings(extendedLevel.ExtendedMod.ModNameAliases, modNames), extendedLevel.name, "Mod Name");
             UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingWithinRanges(extendedLevel.RoutePrice, currentRoutePrice), extendedLevel.name, "Route Price");
             UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedString(extendedLevel.NumberlessPlanetName, planetNames), extendedLevel.name, "Planet Name");
             UpdateRarity(ref returnRarity, GetHighestRarityViaMatchingNormalizedString(extendedLevel.SelectableLevel.currentWeather.ToString(), currentWeather), extendedLevel.name, "Current Weather");
-
 
             return (returnRarity);
         }

--- a/LethalLevelLoader/Components/MatchingProperties/MatchingProperties.cs
+++ b/LethalLevelLoader/Components/MatchingProperties/MatchingProperties.cs
@@ -1,21 +1,27 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UnityEngine;
 
 namespace LethalLevelLoader
 {
-    public class MatchingProperties : ScriptableObject
+    public class MatchingProperties<T> : ScriptableObject where T : ExtendedContent
     {
         [Space(5)] public List<StringWithRarity> modNames = new List<StringWithRarity>();
         [Space(5)] public List<StringWithRarity> authorNames = new List<StringWithRarity>();
 
-        public static MatchingProperties Create(ExtendedContent extendedContent)
+        public static MatchingProperties<T> Create(ExtendedContent extendedContent)
         {
-            MatchingProperties matchingProperties = ScriptableObject.CreateInstance<MatchingProperties>();
+            MatchingProperties<T> matchingProperties = ScriptableObject.CreateInstance<MatchingProperties<T>>();
             matchingProperties.name = extendedContent.name + "MatchingProperties";
             return (matchingProperties);
+        }
+
+        internal virtual int GetDynamicRarity(T content)
+        {
+            int result = 0;
+            UpdateRarity(ref result, GetHighestRarityViaMatchingNormalizedString(content.AuthorName, authorNames), content.name, "Author Name");
+            UpdateRarity(ref result, GetHighestRarityViaMatchingNormalizedStrings(content.ExtendedMod.ModNameAliases, modNames), content.name, "Mod Name Name");
+            return result;
         }
 
         internal static bool UpdateRarity(ref int currentValue, int newValue, string debugActionObject = null, string debugActionReason = null)

--- a/LethalLevelLoader/Patches/DungeonManager.cs
+++ b/LethalLevelLoader/Patches/DungeonManager.cs
@@ -124,20 +124,25 @@ namespace LethalLevelLoader
         internal static bool TryGetExtendedDungeonFlow(DungeonFlow dungeonFlow, out ExtendedDungeonFlow returnExtendedDungeonFlow, ContentType contentType = ContentType.Any)
         {
             returnExtendedDungeonFlow = null;
-            List<ExtendedDungeonFlow> extendedDungeonFlowsList = null;
-
             if (dungeonFlow == null) return (false);
 
-            if (contentType == ContentType.Any)
-                extendedDungeonFlowsList = PatchedContent.ExtendedDungeonFlows;
-            else if (contentType == ContentType.Custom)
-                extendedDungeonFlowsList = PatchedContent.CustomExtendedDungeonFlows;
-            else if (contentType == ContentType.Vanilla)
-                extendedDungeonFlowsList = PatchedContent.VanillaExtendedDungeonFlows;
+            List<ExtendedDungeonFlow> extendedDungeonFlowsList;
+            switch(contentType)
+            {
+                case ContentType.Any: extendedDungeonFlowsList = PatchedContent.ExtendedDungeonFlows; break;
+                case ContentType.Custom: extendedDungeonFlowsList = PatchedContent.CustomExtendedDungeonFlows; break;
+                case ContentType.Vanilla:
+                default:
+                    extendedDungeonFlowsList = PatchedContent.VanillaExtendedDungeonFlows; break;
+            }
 
             foreach (ExtendedDungeonFlow extendedDungeonFlow in extendedDungeonFlowsList)
-                if (extendedDungeonFlow.DungeonFlow == dungeonFlow)
-                    returnExtendedDungeonFlow = extendedDungeonFlow;
+            {
+                if (extendedDungeonFlow.DungeonFlow != dungeonFlow) continue;
+
+                returnExtendedDungeonFlow = extendedDungeonFlow;
+                break;
+            }
 
             return (returnExtendedDungeonFlow != null);
         }

--- a/LethalLevelLoader/Patches/ItemManager.cs
+++ b/LethalLevelLoader/Patches/ItemManager.cs
@@ -1,9 +1,4 @@
-﻿using JetBrains.Annotations;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace LethalLevelLoader
 {
@@ -18,43 +13,45 @@ namespace LethalLevelLoader
         {
             foreach (ExtendedItem extendedItem in PatchedContent.CustomExtendedItems)
             {
-                if (extendedItem.Item.isScrap)
+                if (!extendedItem.Item.isScrap) continue;
+                string debugString = string.Empty;
+                SpawnableItemWithRarity alreadyInjectedItem = null;
+                foreach (SpawnableItemWithRarity spawnableItem in extendedLevel.SelectableLevel.spawnableScrap)
                 {
-                    string debugString = string.Empty;
-                    SpawnableItemWithRarity alreadyInjectedItem = null;
-                    foreach (SpawnableItemWithRarity spawnableItem in extendedLevel.SelectableLevel.spawnableScrap)
-                        if (spawnableItem.spawnableItem == extendedItem)
-                            alreadyInjectedItem = spawnableItem;
+                    if (spawnableItem.spawnableItem != extendedItem) continue;
 
-                    int returnRarity = 0;
-                    int levelRarity = extendedItem.LevelMatchingProperties.GetDynamicRarity(extendedLevel);
-                    //int dungeonRarity
-                    returnRarity = levelRarity;
-                    if (alreadyInjectedItem != null)
+                    alreadyInjectedItem = spawnableItem;
+                    break;
+                }
+
+                int returnRarity = 0;
+                int levelRarity = extendedItem.LevelMatchingProperties.GetDynamicRarity(extendedLevel);
+                //int dungeonRarity
+                returnRarity = levelRarity;
+                if (alreadyInjectedItem != null)
+                {
+                    if (returnRarity > 0)
                     {
-                        if (returnRarity > 0)
-                        {
-                            alreadyInjectedItem.rarity = returnRarity;
-                            debugString = "Updated Rarity Of: " + extendedItem.Item.itemName + " To: " + returnRarity + " On Planet: " + extendedLevel.NumberlessPlanetName;
-                        }
-                        else
-                        {
-                            extendedLevel.SelectableLevel.spawnableScrap.Remove(alreadyInjectedItem);
-                            debugString = "Removed " + extendedItem.Item.itemName + " From Planet: " + extendedLevel.NumberlessPlanetName;
-                        }
- 
+                        alreadyInjectedItem.rarity = returnRarity;
+                        debugString = "Updated Rarity Of: " + extendedItem.Item.itemName + " To: " + returnRarity + " On Planet: " + extendedLevel.NumberlessPlanetName;
                     }
                     else
                     {
-                        SpawnableItemWithRarity newSpawnableItem = new SpawnableItemWithRarity();
-                        newSpawnableItem.spawnableItem = extendedItem.Item;
-                        newSpawnableItem.rarity = returnRarity;
-                        extendedLevel.SelectableLevel.spawnableScrap.Add(newSpawnableItem);
-                        debugString = "Added " + extendedItem.Item.itemName + " To Planet: " + extendedLevel.NumberlessPlanetName + " With A Rarity Of: " + returnRarity;
+                        extendedLevel.SelectableLevel.spawnableScrap.Remove(alreadyInjectedItem);
+                        debugString = "Removed " + extendedItem.Item.itemName + " From Planet: " + extendedLevel.NumberlessPlanetName;
                     }
-                    if (debugResults == true)
-                        DebugHelper.Log(debugString, DebugType.Developer);
+ 
                 }
+                else
+                {
+                    SpawnableItemWithRarity newSpawnableItem = new SpawnableItemWithRarity();
+                    newSpawnableItem.spawnableItem = extendedItem.Item;
+                    newSpawnableItem.rarity = returnRarity;
+                    extendedLevel.SelectableLevel.spawnableScrap.Add(newSpawnableItem);
+                    debugString = "Added " + extendedItem.Item.itemName + " To Planet: " + extendedLevel.NumberlessPlanetName + " With A Rarity Of: " + returnRarity;
+                }
+                if (debugResults == true)
+                    DebugHelper.Log(debugString, DebugType.Developer);
             }
         }
 

--- a/LethalLevelLoader/Patches/LevelManager.cs
+++ b/LethalLevelLoader/Patches/LevelManager.cs
@@ -1,12 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using Unity.AI.Navigation;
-using Unity.Netcode;
 using UnityEngine;
-using UnityEngine.Events;
-using UnityEngine.SceneManagement;
 
 namespace LethalLevelLoader
 {
@@ -84,20 +79,25 @@ namespace LethalLevelLoader
         public static bool TryGetExtendedLevel(SelectableLevel selectableLevel, out ExtendedLevel returnExtendedLevel, ContentType levelType = ContentType.Any)
         {
             returnExtendedLevel = null;
-            List<ExtendedLevel> extendedLevelsList = null;
-
             if (selectableLevel == null) return false;
 
-            if (levelType == ContentType.Any)
-                extendedLevelsList = PatchedContent.ExtendedLevels;
-            else if (levelType == ContentType.Custom)
-                extendedLevelsList = PatchedContent.CustomExtendedLevels;
-            else if (levelType == ContentType.Vanilla)
-                extendedLevelsList = PatchedContent.VanillaExtendedLevels;
+            List<ExtendedLevel> extendedLevelsList;
+            switch(levelType)
+            {
+                case ContentType.Any: extendedLevelsList = PatchedContent.ExtendedLevels; break;
+                case ContentType.Custom: extendedLevelsList = PatchedContent.CustomExtendedLevels; break;
+                case ContentType.Vanilla:
+                default:
+                    extendedLevelsList = PatchedContent.VanillaExtendedLevels; break;
+            }
 
             foreach (ExtendedLevel extendedLevel in extendedLevelsList)
-                if (extendedLevel.SelectableLevel == selectableLevel)
-                    returnExtendedLevel = extendedLevel;
+            {
+                if (extendedLevel.SelectableLevel != selectableLevel) continue;
+
+                returnExtendedLevel = extendedLevel;
+                break;
+            }
 
             return (returnExtendedLevel != null);
         }

--- a/LethalLevelLoader/Patches/LevelManager.cs
+++ b/LethalLevelLoader/Patches/LevelManager.cs
@@ -105,10 +105,13 @@ namespace LethalLevelLoader
         public static ExtendedLevel GetExtendedLevel(SelectableLevel selectableLevel)
         {
             ExtendedLevel returnExtendedLevel = null;
-
             foreach (ExtendedLevel extendedLevel in PatchedContent.ExtendedLevels)
-                if (extendedLevel.SelectableLevel == selectableLevel)
-                    returnExtendedLevel = extendedLevel;
+            {
+                if (extendedLevel.SelectableLevel != selectableLevel) continue;
+
+                returnExtendedLevel = extendedLevel;
+                break;
+            }
 
             return (returnExtendedLevel);
         }

--- a/LethalLevelLoader/Patches/NetworkBundleManager.cs
+++ b/LethalLevelLoader/Patches/NetworkBundleManager.cs
@@ -89,7 +89,7 @@ namespace LethalLevelLoader
                     bundleGroup.TryLoadGroup();
 
             if (IsServer)
-                RequestLoadStatusRefreshServer();
+                RequestLoadStatusRefreshServerRpc();
         }
 
         //Called by StartOfRound.OnClientConnect.Postfix
@@ -97,10 +97,11 @@ namespace LethalLevelLoader
         internal void OnClientsChangedRefresh()
         {
             if (!IsServer) return;
-            RequestLoadStatusRefreshServer();
+            RequestLoadStatusRefreshServerRpc();
         }
 
-        internal void RequestLoadStatusRefreshServer()
+        [ServerRpc(RequireOwnership = false)]
+        internal void RequestLoadStatusRefreshServerRpc()
         {
             DebugHelper.Log("Refeshing Loaded Bundles Status!", DebugType.User);
             playersLoadStatus.Clear();
@@ -139,7 +140,7 @@ namespace LethalLevelLoader
             if (playersLoadStatus.Count <= index)
             {
                 DebugHelper.LogError("Tried To Set LoadedStatus When List Is Invalid (ClientID: " + clientID + ", Index: " + index + "), Resetting.", DebugType.User);
-                RequestLoadStatusRefreshServer();
+                RequestLoadStatusRefreshServerRpc();
                 return;
             }
 

--- a/LethalLevelLoader/Patches/NetworkBundleManager.cs
+++ b/LethalLevelLoader/Patches/NetworkBundleManager.cs
@@ -89,7 +89,7 @@ namespace LethalLevelLoader
                     bundleGroup.TryLoadGroup();
 
             if (IsServer)
-                RequestLoadStatusRefreshServerRpc();
+                RequestLoadStatusRefreshServer();
         }
 
         //Called by StartOfRound.OnClientConnect.Postfix
@@ -97,11 +97,10 @@ namespace LethalLevelLoader
         internal void OnClientsChangedRefresh()
         {
             if (!IsServer) return;
-            RequestLoadStatusRefreshServerRpc();
+            RequestLoadStatusRefreshServer();
         }
 
-        [ServerRpc(RequireOwnership = false)]
-        internal void RequestLoadStatusRefreshServerRpc()
+        internal void RequestLoadStatusRefreshServer()
         {
             DebugHelper.Log("Refeshing Loaded Bundles Status!", DebugType.User);
             playersLoadStatus.Clear();
@@ -140,7 +139,7 @@ namespace LethalLevelLoader
             if (playersLoadStatus.Count <= index)
             {
                 DebugHelper.LogError("Tried To Set LoadedStatus When List Is Invalid (ClientID: " + clientID + ", Index: " + index + "), Resetting.", DebugType.User);
-                RequestLoadStatusRefreshServerRpc();
+                RequestLoadStatusRefreshServer();
                 return;
             }
 

--- a/LethalLevelLoader/Patches/TerminalManager.cs
+++ b/LethalLevelLoader/Patches/TerminalManager.cs
@@ -328,19 +328,20 @@ namespace LethalLevelLoader
                 string groupString = string.Empty;
                 foreach (ExtendedLevel extendedLevel in extendedLevelGroup.extendedLevelsList)
                     if (extendedLevel.IsRouteHidden == false)
-                        groupString += "* " + extendedLevel.NumberlessPlanetName + " " + GetExtendedLevelPreviewInfo(extendedLevel) + "\n";
+                        groupString += $"* {extendedLevel.NumberlessPlanetName} {GetExtendedLevelPreviewInfo(extendedLevel)}\n";
                 if (!string.IsNullOrEmpty(groupString))
                     returnString += groupString + "\n";
 
             }
-            if (returnString.Contains("\n"))
-                returnString.Replace(returnString.Substring(returnString.LastIndexOf("\n")), "");
 
-            string tagString = Settings.levelPreviewFilterType.ToString().ToUpper();
-            if (Settings.levelPreviewFilterType == FilterInfoType.Tag)
-                tagString = currentTagFilter.ToUpper();
+            string tagString;
+            switch(Settings.levelPreviewFilterType)
+            {
+                case FilterInfoType.Tag: tagString = currentTagFilter.ToUpper(); break;
+                default: tagString = Settings.levelPreviewFilterType.ToString().ToUpper(); break;
+            }
 
-            return (returnString + "\n" + "____________________________" + "\n" + "PREVIEW: " + Settings.levelPreviewInfoType.ToString().ToUpper() + " | " + "SORT: " + Settings.levelPreviewSortType.ToString().ToUpper() + " | " + "FILTER: " + tagString + "\n");
+            return (returnString + $"\n____________________________\nPREVIEW: {Settings.levelPreviewInfoType.ToString().ToUpper()} | SORT: {Settings.levelPreviewSortType.ToString().ToUpper()} | FILTER: {tagString}\n");
         }
 
         public static string GetExtendedLevelPreviewInfo(ExtendedLevel extendedLevel)

--- a/LethalLevelLoader/Patches/TerminalManager.cs
+++ b/LethalLevelLoader/Patches/TerminalManager.cs
@@ -228,28 +228,21 @@ namespace LethalLevelLoader
 
         internal static void FilterMoonsCataloguePage(MoonsCataloguePage moonsCataloguePage)
         {
-            List<ExtendedLevel> removeLevelList = new List<ExtendedLevel>();
-
             foreach (ExtendedLevelGroup extendedLevelGroup in moonsCataloguePage.ExtendedLevelGroups)
                 foreach (ExtendedLevel extendedLevel in new List<ExtendedLevel>(extendedLevelGroup.extendedLevelsList))
                 {
                     bool removeExtendedLevel = extendedLevel.IsRouteHidden;
+                    switch(Settings.levelPreviewFilterType)
+                    {
+                        case FilterInfoType.Price: removeExtendedLevel |= extendedLevel.RoutePrice > Terminal.groupCredits; break;
+                        case FilterInfoType.Weather: removeExtendedLevel |= GetWeatherConditions(extendedLevel) != string.Empty; break;
+                        case FilterInfoType.Tag: removeExtendedLevel |= !extendedLevel.TryGetTag(currentTagFilter); break;
+                        default: removeExtendedLevel = extendedLevel.IsRouteHidden; break;
+                    }
 
-                    if (Settings.levelPreviewFilterType.Equals(FilterInfoType.Price))
-                        removeExtendedLevel = (extendedLevel.RoutePrice > Terminal.groupCredits);
-                    else if (Settings.levelPreviewFilterType.Equals(FilterInfoType.Weather))
-                        removeExtendedLevel = (GetWeatherConditions(extendedLevel) != string.Empty);
-                    else if (Settings.levelPreviewFilterType.Equals(FilterInfoType.Tag))
-                        removeExtendedLevel = (!extendedLevel.TryGetTag(currentTagFilter));
-
-                    if (removeExtendedLevel == true)
-                        removeLevelList.Add(extendedLevel);
-                }
-
-            foreach (ExtendedLevelGroup extendedLevelGroup in moonsCataloguePage.ExtendedLevelGroups)
-                foreach (ExtendedLevel extendedLevel in removeLevelList)
-                    if (extendedLevelGroup.extendedLevelsList.Contains(extendedLevel))
+                    if (removeExtendedLevel)
                         extendedLevelGroup.extendedLevelsList.Remove(extendedLevel);
+                }
 
             if (Settings.levelPreviewFilterType != FilterInfoType.None)
                 moonsCataloguePage.RebuildLevelGroups(new List<ExtendedLevelGroup>(moonsCataloguePage.ExtendedLevelGroups), Settings.moonsCatalogueSplitCount);

--- a/LethalLevelLoader/Tools/AssetBundleLoader.cs
+++ b/LethalLevelLoader/Tools/AssetBundleLoader.cs
@@ -545,7 +545,7 @@ namespace LethalLevelLoader
                 extendedLevel.name = extendedLevel.NumberlessPlanetName + "ExtendedLevel";
 
                 PatchedContent.ExtendedLevels.Add(extendedLevel);
-                PatchedContent.VanillaMod.RegisterExtendedContent(extendedLevel);
+                extendedLevel.Register(PatchedContent.VanillaMod);
             }
         }
 
@@ -651,7 +651,7 @@ namespace LethalLevelLoader
             extendedDungeonFlow.DungeonName = dungeonDisplayName;
 
             extendedDungeonFlow.Initialize();
-            PatchedContent.VanillaMod.RegisterExtendedContent(extendedDungeonFlow);
+            extendedDungeonFlow.Register(PatchedContent.VanillaMod);
             PatchedContent.ExtendedDungeonFlows.Add(extendedDungeonFlow);
 
             if (extendedDungeonFlow.DungeonID == -1)
@@ -668,7 +668,7 @@ namespace LethalLevelLoader
         internal static void CreateVanillaExtendedBuyableVehicle(BuyableVehicle buyableVehicle)
         {
             ExtendedBuyableVehicle newExtendedVanillaBuyableVehicle = ExtendedBuyableVehicle.Create(buyableVehicle);
-            PatchedContent.VanillaMod.RegisterExtendedContent(newExtendedVanillaBuyableVehicle);
+            newExtendedVanillaBuyableVehicle.Register(PatchedContent.VanillaMod);
             PatchedContent.ExtendedBuyableVehicles.Add(newExtendedVanillaBuyableVehicle);
         }
 

--- a/LethalLevelLoader/Tools/AssetBundleLoader.cs
+++ b/LethalLevelLoader/Tools/AssetBundleLoader.cs
@@ -92,7 +92,9 @@ namespace LethalLevelLoader
                 foreach (ExtendedBuyableVehicle extendedBuyableVehicle in extendedMod.ExtendedBuyableVehicles)
                 {
                     LethalLevelLoaderNetworkManager.RegisterNetworkPrefab(extendedBuyableVehicle.BuyableVehicle.vehiclePrefab);
-                    LethalLevelLoaderNetworkManager.RegisterNetworkPrefab(extendedBuyableVehicle.BuyableVehicle.secondaryPrefab);
+
+                    if (extendedBuyableVehicle.BuyableVehicle.secondaryPrefab != null)
+                        LethalLevelLoaderNetworkManager.RegisterNetworkPrefab(extendedBuyableVehicle.BuyableVehicle.secondaryPrefab);
                 }
             }
         }

--- a/LethalLevelLoader/Tools/Validators.cs
+++ b/LethalLevelLoader/Tools/Validators.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Unity.Netcode;
+﻿using Unity.Netcode;
 using UnityEngine;
 
 namespace LethalLevelLoader
@@ -32,7 +29,29 @@ namespace LethalLevelLoader
 
             return (result.Item1);
         }
-        
+
+        public static (bool,string) VerbValidateExtendedContent(ExtendedContent extendedContent)
+        {
+            (bool, string) result = (false, string.Empty);
+
+            if (extendedContent is ExtendedLevel extendedLevel)
+                result = ValidateExtendedContent(extendedLevel);
+            else if (extendedContent is ExtendedDungeonFlow extendedDungeonFlow)
+                result = ValidateExtendedContent(extendedDungeonFlow);
+            else if (extendedContent is ExtendedItem extendedItem)
+                result = ValidateExtendedContent(extendedItem);
+            else if (extendedContent is ExtendedEnemyType extendedEnemyType)
+                result = ValidateExtendedContent(extendedEnemyType);
+            else if (extendedContent is ExtendedFootstepSurface extendedFootstepSurface)
+                result = ValidateExtendedContent(extendedFootstepSurface);
+            else if (extendedContent is ExtendedStoryLog extendedStoryLog)
+                result = ValidateExtendedContent(extendedStoryLog);
+            else if (extendedContent is ExtendedBuyableVehicle extendedBuyableVehicle)
+                result = ValidateExtendedContent(extendedBuyableVehicle);
+
+            return result;
+        }
+
         public static (bool result, string log) ValidateExtendedContent(ExtendedItem extendedItem)
         {
             if (extendedItem == null)


### PR DESCRIPTION
``LoadAllBundlesRequest``: Changed ``LoadAllBundles`` method signature to accept as parameter the collection of strings which represent the files retrieved from the ``Directory.GetFiles`` callback, reducing the number of callbacks of ``Directory.GetFiles`` from two to one.

``OnInitialBundlesProcessed``: Fixed the loop always skipping the remaining elements of ``newGroup.GetAssetBundleInfos()`` after the first iteration.

``RegisterExtendedMod``: Changed the loop iteration to stop once it has a found matching extended mod and used switch case statement for ``extendedMod.ModMergeSetting`` to know what needs to be checked for matching.

``TryGetExtendedDungeonFlow``: Used switch case statement to define what collection to use for iteration and stopped the iteration once an extended dungeonflow has been found.

``InjectCustomItemsIntoLevelViaDynamicRarity``: Loop iteration on ``extendedLevel.SelectableLevel.spawnableScrap`` is stopped once it has found an already injected item.

``TryGetExtendedLevel``: Used switch case statement to define the collection for iteration and stopped the iteration loop once an extended level has been found.

``GetExtendedLevel``: Stopped the iteration loop once an extended level has been found.

``FilterMoonsCataloguePage``: Merged two iterations into one, used switch case statement to define the criteria to wether it is shown or not in the catalogue. Also changed the filter to include the check of wether the moon is hidden or not (any defined filter would ignore the route hidden check)

``GetMoonCatalogDisplayListings``: Removed if statement related to string replacement as it was both not being used in the end result of the message and it didn't seem to produce the desired result as it would make the catalogue unreadable. Changed string construction to use interpolation instead for easier understanding. Used switch case statement to define the contents of ``tagString``

``NetworkRegisterCustomContent``: Added null check on ``BuyableVehicle.secondaryPrefab`` to avoid registering a null prefab. This is safe to do because ``ItemDropship`` checks if the selected ``BuyableVehicle`` has a non-null ``secondaryPrefab`` to spawn it in ``DeliverVehicleOnServer``. (fixes #173)

- ``MatchingProperties`` takes a type parameter which is ``ExtendedContent``. This means:
  - ``LevelMatchingProperties`` is a ``MatchingProperties<ExtendedLevel>``
  - ``DungeonMatchingProperties`` is a ``MatchingProperties<ExtendedDungeonFlow>``
- Turned ``GetDynamicRarity()`` to virtual which takes as parameter the extended content. This is then overriden with respective derived classes to include additional rarities.

- Changed ``RegisterExtendedContent`` to not have a series of if statements checking the explicit type of the ``ExtendedContent`` parameter and instead just made a ``Register`` method which is overriden by all its derived classes and it calls this method instead, removing the need for explicit type checks.
- Same logic with ``UnregisterExtendedContent``