### PR TITLE
Fix for SpawnableMapObjects only spawning for the host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 **Changelog**
 --
 
+**<details><summary>Version 1.4.12</summary>**
+
+**<details><summary>Fixes</summary>**
+
+* Fixed SpawnableMapObjects defined in ExtendedDungeonFlow not spawning for clients
+
+</details>
+
 **<details><summary>Version 1.4.11</summary>**
 
 **<details><summary>Fixes</summary>**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **<details><summary>Fixes</summary>**
 
 * Fixed SpawnableMapObjects defined in ExtendedDungeonFlow not spawning for clients
+* Fixed some ExtendedContent not being re-registered on the terminal after a lobby reload
 
 </details>
 

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedStoryLog.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedStoryLog.cs
@@ -18,5 +18,7 @@ namespace LethalLevelLoader
         [TextArea] public string storyLogDescription = string.Empty;
 
         [HideInInspector] internal int newStoryLogID;
+
+        [HideInInspector] internal TerminalNode assignedNode;
     }
 }

--- a/LethalLevelLoader/General/Patches.cs
+++ b/LethalLevelLoader/General/Patches.cs
@@ -370,6 +370,48 @@ if (AssetBundleLoader.noBundlesFound == true)
 
                 TerminalManager.AddTerminalNodeEventListener(TerminalManager.moonsKeyword.specialKeywordResult, TerminalManager.RefreshMoonsCataloguePage, TerminalManager.LoadNodeActionType.After);
             }
+            else
+            {
+                // Populate Terminal lists with already-existing ExtendedContent:
+                foreach (ExtendedMod extendedMod in PatchedContent.ExtendedMods)
+                {
+                    // Load ExtendedItem store page entries:
+                    if (extendedMod.ExtendedItems.Count > 0)
+                    {
+                        List<Item> allBuyableItems = [.. Terminal.buyableItemsList];
+
+                        foreach (ExtendedItem extendedItem in extendedMod.ExtendedItems)
+                            if (extendedItem.IsBuyableItem)
+                                allBuyableItems.Add(extendedItem.Item);
+
+                        Terminal.buyableItemsList = [.. allBuyableItems];
+                    }
+                    // ...
+
+                    // Load ExtendedEnemyType beastiary entries.
+                    if (extendedMod.ExtendedEnemyTypes.Count > 0)
+                        foreach (ExtendedEnemyType extendedEnemy in extendedMod.ExtendedEnemyTypes)
+                            Terminal.enemyFiles.Add(extendedEnemy.EnemyInfoNode);
+
+                    // Load ExtendedStoryLog journal entries.
+                    if (extendedMod.ExtendedStoryLogs.Count > 0)
+                        foreach (ExtendedStoryLog extendedStoryLog in extendedMod.ExtendedStoryLogs)
+                            Terminal.logEntryFiles.Add(extendedStoryLog.assignedNode);
+
+                    // Load ExtendedBuyableVehicle store page entries:
+                    if (extendedMod.ExtendedBuyableVehicles.Count > 0)
+                    {
+                        List<BuyableVehicle> allVehicles = [.. Terminal.buyableVehicles];
+
+                        foreach (ExtendedBuyableVehicle extendedBuyableVehicle in extendedMod.ExtendedBuyableVehicles)
+                            allVehicles.Add(extendedBuyableVehicle.BuyableVehicle);
+
+                        Terminal.buyableVehicles = [.. allVehicles];
+                    }
+                    // ...
+                }
+                // ...
+            }
 
             LevelLoader.defaultFootstepSurfaces = new List<FootstepSurface>(StartOfRound.footstepSurfaces).ToArray();
 

--- a/LethalLevelLoader/LethalLevelLoader.csproj
+++ b/LethalLevelLoader/LethalLevelLoader.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 
       <TargetFramework>netstandard2.1</TargetFramework>
       <AssemblyName>LethalLevelLoader</AssemblyName>
       <Description>A Custom API to support the manual and dynamic integration of custom levels and dungeons in Lethal Company.</Description>
-      <Version>1.3.15</Version>
+      <Version>1.4.12</Version>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
       <LangVersion>preview</LangVersion>
 

--- a/LethalLevelLoader/Patches/TerminalManager.cs
+++ b/LethalLevelLoader/Patches/TerminalManager.cs
@@ -710,6 +710,7 @@ namespace LethalLevelLoader
             newStoryLogNode.creatureName = newStoryLog.storyLogTitle;
             newStoryLogNode.storyLogFileID = Terminal.logEntryFiles.Count;
             newStoryLog.newStoryLogID = Terminal.logEntryFiles.Count;
+            newStoryLog.assignedNode = newStoryLogNode;
 
             Terminal.logEntryFiles.Add(newStoryLogNode);
             viewKeyword.AddCompatibleNoun(newStoryLogKeyword, newStoryLogNode);

--- a/LethalLevelLoader/Plugin.cs
+++ b/LethalLevelLoader/Plugin.cs
@@ -17,7 +17,7 @@ namespace LethalLevelLoader
     {
         public const string ModGUID = "imabatby.lethallevelloader";
         public const string ModName = "LethalLevelLoader";
-        public const string ModVersion = "1.4.11";
+        public const string ModVersion = "1.4.12";
 
         internal static Plugin Instance;
 

--- a/LethalLevelLoader/Tools/AssetBundleLoader.cs
+++ b/LethalLevelLoader/Tools/AssetBundleLoader.cs
@@ -690,6 +690,7 @@ namespace LethalLevelLoader
                 registeredPrefabs.Add(networkPrefab.Prefab);
 
             List<SpawnSyncedObject> spawnSyncedObjects = extendedDungeonFlow.DungeonFlow.GetSpawnSyncedObjects();
+            List<SpawnableMapObject> extendedSpawnableMapObjects = extendedDungeonFlow.SpawnableMapObjects;
 
             foreach (GameObject registeredPrefab in registeredPrefabs)
             {
@@ -702,6 +703,16 @@ namespace LethalLevelLoader
                             restoredObjectsDebugList.Add(registeredPrefab.name);
                     }
 
+                // Just in case it's already registered as a network prefab for whatever reason, though it might not be necessary:
+                foreach (SpawnableMapObject spawnableMapObject in new List<SpawnableMapObject>(extendedSpawnableMapObjects))
+                    if(spawnableMapObject.prefabToSpawn != null && spawnableMapObject.prefabToSpawn.name == registeredPrefab.name)
+                    {
+                        spawnableMapObject.prefabToSpawn = registeredPrefab;
+                        extendedSpawnableMapObjects.Remove(spawnableMapObject);
+                        if(!restoredObjectsDebugList.Contains(registeredPrefab.name))
+                            restoredObjectsDebugList.Add(registeredPrefab.name);
+                    }
+                // ...
             }
             foreach (SpawnSyncedObject spawnSyncedObject in spawnSyncedObjects)
             {
@@ -713,6 +724,18 @@ namespace LethalLevelLoader
 
                     if (!registeredObjectsDebugList.Contains(spawnSyncedObject.spawnPrefab.name))
                         registeredObjectsDebugList.Add(spawnSyncedObject.spawnPrefab.name);
+                }
+            }
+            foreach (SpawnableMapObject spawnableMapObject in extendedSpawnableMapObjects)
+            {
+                if(spawnableMapObject != null && spawnableMapObject.prefabToSpawn != null)
+                {
+                    if(!spawnableMapObject.prefabToSpawn.TryGetComponent(out NetworkObject _))
+                        spawnableMapObject.prefabToSpawn.AddComponent<NetworkObject>();
+                    LethalLevelLoaderNetworkManager.RegisterNetworkPrefab(spawnableMapObject.prefabToSpawn);
+
+                    if(!registeredObjectsDebugList.Contains(spawnableMapObject.prefabToSpawn.name))
+                        registeredObjectsDebugList.Add(spawnableMapObject.prefabToSpawn.name);
                 }
             }
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 **Description**
 --
 
-### **1.4.11 for Lethal Company v69 Has Released!**
+### **1.4.12 for Lethal Company v69 Has Released!**
 
 **LethalLevelLoader** is a custom API to support the manual and dynamic integration of custom levels and dungeons in Lethal Company.  
 Mod Developers can provide LethalLevelLoader with their custom content via code or via automatic AssetBundle detection, and from there LethalLevelLoader will seamlessly load the content into the game.

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "LethalLevelLoader",
-    "version_number": "1.4.11",
+    "version_number": "1.4.12",
     "website_url": "https://github.com/IAmBatby/LethalLevelLoader",
     "description": "A Custom API to support the manual and dynamic integration of all forms of custom content in Lethal Company. (v69 Compatible)",
     "dependencies": [


### PR DESCRIPTION
- Added section for registering SpawnableMapObjects as network prefabs to [AssetBundleLoader.cs](https://github.com/IAmBatby/LethalLevelLoader/blob/97f60a501071e58f9c4fce0d5edcc2dabc6a8520/LethalLevelLoader/Tools/AssetBundleLoader.cs#L693-L740)
- Also bumped LLL version to 1.4.12