### PR TITLE
Added ExtendedUnlockableItem ExtendedContent type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,16 @@
 
 **<details><summary>Version 1.4.12</summary>**
 
+**<details><summary>Features</summary>**
+
+* Updated mod for Lethal Company version 70
+* Added ExtendedUnlockableItem (suits, ship furniture, ship upgrades)
+
 **<details><summary>Fixes</summary>**
 
 * Fixed SpawnableMapObjects defined in ExtendedDungeonFlow not spawning for clients
 * Fixed some ExtendedContent not being re-registered on the terminal after a lobby reload
+* Fixed OnLethalBundleLoaded listeners being called multiple times (once for every bundle found)
 
 </details>
 

--- a/LethalLevelLoader/AssetBundles/AssetBundleInfo.cs
+++ b/LethalLevelLoader/AssetBundles/AssetBundleInfo.cs
@@ -16,7 +16,7 @@ namespace LethalLevelLoader.AssetBundles
     public class AssetBundleInfo
     {
         private bool hasInitialized;
-        internal AssetBundle assetBundle; // Increased accessibility solely for convenience.
+        private AssetBundle assetBundle;
         private MonoBehaviour coroutineHandler;
         private AssetBundleCreateRequest activeLoadRequest;
         private AssetBundleUnloadOperation activeUnloadRequest;

--- a/LethalLevelLoader/AssetBundles/AssetBundleInfo.cs
+++ b/LethalLevelLoader/AssetBundles/AssetBundleInfo.cs
@@ -16,7 +16,7 @@ namespace LethalLevelLoader.AssetBundles
     public class AssetBundleInfo
     {
         private bool hasInitialized;
-        private AssetBundle assetBundle;
+        internal AssetBundle assetBundle; // Increased accessibility solely for convenience.
         private MonoBehaviour coroutineHandler;
         private AssetBundleCreateRequest activeLoadRequest;
         private AssetBundleUnloadOperation activeUnloadRequest;

--- a/LethalLevelLoader/AssetBundles/AssetBundleLoader.cs
+++ b/LethalLevelLoader/AssetBundles/AssetBundleLoader.cs
@@ -238,8 +238,10 @@ namespace LethalLevelLoader.AssetBundles
                         {
                             if (info.AssetBundleName == lethalBundleRequest.Key)
                             {
-                                foreach (Action<AssetBundle> bundleEvent in lethalBundleRequest.Value)
-                                    bundleEvent.Invoke(info.assetBundle);
+                                AssetBundle newBundle = AssetBundle.GetAllLoadedAssetBundles().First(bundle => bundle.name == info.AssetBundleName);
+                                if (newBundle != null)
+                                    foreach (Action<AssetBundle> bundleEvent in lethalBundleRequest.Value)
+                                        bundleEvent.Invoke(newBundle);
                                 break;
                             }
                         }

--- a/LethalLevelLoader/AssetBundles/AssetBundleLoader.cs
+++ b/LethalLevelLoader/AssetBundles/AssetBundleLoader.cs
@@ -233,14 +233,13 @@ namespace LethalLevelLoader.AssetBundles
                             break;
                         }
 
-                    List<AssetBundle> allLoadedBundles = new List<AssetBundle>(AssetBundle.GetAllLoadedAssetBundles());
                     foreach (KeyValuePair<string, List<Action<AssetBundle>>> lethalBundleRequest in onLethalBundleLoadedRequestDict)
-                        foreach (AssetBundle bundle in allLoadedBundles)
+                        foreach (AssetBundleInfo info in newGroup.GetAssetBundleInfos())
                         {
-                            if (bundle != null && bundle.name == lethalBundleRequest.Key)
+                            if (info.AssetBundleName == lethalBundleRequest.Key)
                             {
                                 foreach (Action<AssetBundle> bundleEvent in lethalBundleRequest.Value)
-                                    bundleEvent.Invoke(bundle);
+                                    bundleEvent.Invoke(info.assetBundle);
                                 break;
                             }
                         }

--- a/LethalLevelLoader/AssetBundles/LethalBundleManager.cs
+++ b/LethalLevelLoader/AssetBundles/LethalBundleManager.cs
@@ -194,6 +194,10 @@ namespace LethalLevelLoader
             {
                 extendedMod = GetOrCreateExtendedMod(source, extendedBuyableVehicle.name);
             }
+            else if (extendedContent is ExtendedUnlockableItem extendedUnlockableItem)
+            {
+                extendedMod = GetOrCreateExtendedMod(source, extendedUnlockableItem.name);
+            }
 
             if (extendedMod != null)
             {

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedMod.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedMod.cs
@@ -40,6 +40,9 @@ namespace LethalLevelLoader
         public List<ExtendedBuyableVehicle> ExtendedBuyableVehicles { get; private set; } = new List<ExtendedBuyableVehicle>();
 
         [field: SerializeField]
+        public List<ExtendedUnlockableItem> ExtendedUnlockableItems { get; private set; } = new List<ExtendedUnlockableItem>();
+
+        [field: SerializeField]
         public List<string> StreamingLethalBundleNames { get; private set; } = new List<string>();
 
         public List<ExtendedContent> ExtendedContents
@@ -63,6 +66,8 @@ namespace LethalLevelLoader
                     returnList.Add(storyLog);
                 foreach (ExtendedBuyableVehicle vehicle in ExtendedBuyableVehicles)
                     returnList.Add(vehicle);
+                foreach (ExtendedUnlockableItem unlockableItem in ExtendedUnlockableItems)
+                    returnList.Add(unlockableItem);
 
                 return (returnList);
             }
@@ -126,6 +131,8 @@ namespace LethalLevelLoader
                         RegisterExtendedContent(extendedStoryLog);
                     else if (newExtendedContent is ExtendedBuyableVehicle extendedBuyableVehicle)
                         RegisterExtendedContent(extendedBuyableVehicle);
+                    else if (newExtendedContent is ExtendedUnlockableItem extendedUnlockableItem)
+                        RegisterExtendedContent(extendedUnlockableItem);
                     else
                         throw new ArgumentException(nameof(newExtendedContent), newExtendedContent.name + " (" + newExtendedContent.GetType().Name + ") " + " Could Not Be Registered To ExtendedMod: " + ModName + " Due To Unimplemented Registration Check!");
                 }
@@ -210,6 +217,15 @@ namespace LethalLevelLoader
             extendedBuyableVehicle.ExtendedMod = this;
         }
 
+        internal void RegisterExtendedContent(ExtendedUnlockableItem extendedUnlockableItem)
+        {
+            TryThrowInvalidContentException(extendedUnlockableItem, Validators.ValidateExtendedContent(extendedUnlockableItem));
+
+            ExtendedUnlockableItems.Add(extendedUnlockableItem);
+            extendedUnlockableItem.ContentTags.Add(ContentTag.Create("Custom"));
+            extendedUnlockableItem.ExtendedMod = this;
+        }
+
         internal void TryThrowInvalidContentException(ExtendedContent extendedContent, (bool,string) result)
         {
             if (result.Item1 == false)
@@ -229,6 +245,8 @@ namespace LethalLevelLoader
                 ExtendedDungeonFlows.Remove(extendedDungeonFlow);
             else if (currentExtendedContent is ExtendedItem extendedItem)
                 ExtendedItems.Remove(extendedItem);
+            else if (currentExtendedContent is ExtendedUnlockableItem extendedUnlockableItem)
+                ExtendedUnlockableItems.Remove(extendedUnlockableItem);
 
             currentExtendedContent.ExtendedMod = null;
             DebugHelper.LogWarning("Unregistered ExtendedContent: " + currentExtendedContent.name + " In ExtendedMod: " + ModName, DebugType.Developer);
@@ -244,6 +262,7 @@ namespace LethalLevelLoader
             ExtendedFootstepSurfaces.Clear();
             ExtendedStoryLogs.Clear();
             ExtendedBuyableVehicles.Clear();
+            ExtendedUnlockableItems.Clear();
         }
 
         internal void SortRegisteredContent()
@@ -256,6 +275,7 @@ namespace LethalLevelLoader
             ExtendedFootstepSurfaces.Sort((s1, s2) => s1.name.CompareTo(s2.name));
             ExtendedStoryLogs.Sort((s1, s2) => s1.name.CompareTo(s2.name));
             ExtendedBuyableVehicles.Sort((s1, s2) => s1.name.CompareTo(s2.name));
+            ExtendedUnlockableItems.Sort((s1, s2) => s1.name.CompareTo(s2.name));
         }
     }
 }

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedUnlockableItem.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedUnlockableItem.cs
@@ -30,6 +30,9 @@ namespace LethalLevelLoader
         public void Initialize()
         {
             TerminalManager.CreateUnlockableItemTerminalData(this);
+
+            if (!Patches.StartOfRound.unlockablesList.unlockables.Contains(UnlockableItem))
+                Patches.StartOfRound.unlockablesList.unlockables.Add(UnlockableItem);
         }
 
         internal static ExtendedUnlockableItem Create(UnlockableItem newUnlockableItem, ExtendedMod extendedMod, ContentType contentType)

--- a/LethalLevelLoader/Components/ExtendedContent/ExtendedUnlockableItem.cs
+++ b/LethalLevelLoader/Components/ExtendedContent/ExtendedUnlockableItem.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+
+namespace LethalLevelLoader
+{
+    [CreateAssetMenu(fileName = "ExtendedUnlockableItem", menuName = "Lethal Level Loader/Extended Content/ExtendedUnlockableItem", order = 21)]
+    public class ExtendedUnlockableItem : ExtendedContent
+    {
+        [field: Header("General Settings")]
+
+        [field: SerializeField] public UnlockableItem UnlockableItem { get; set; }
+
+        [field: SerializeField] public int ItemCost { get; set; }
+
+        [field: Space(5)]
+        [field: Header("Terminal Store & Info Override Settings")]
+
+        [field: TextArea(2, 20)]
+        [field: SerializeField] public string OverrideInfoNodeDescription { get; set; } = string.Empty;
+        [field: TextArea(2, 20)]
+        [field: SerializeField] public string OverrideBuyNodeDescription { get; set; } = string.Empty;
+        [field: TextArea(2, 20)]
+        [field: SerializeField] public string OverrideBuyConfirmNodeDescription { get; set; } = string.Empty;
+
+        public int UnlockableItemID { get; set; } = -1;
+
+        public TerminalNode BuyNode { get; internal set; }
+        public TerminalNode BuyConfirmNode { get; internal set; }
+        public TerminalNode BuyInfoNode { get; internal set; }
+
+        public void Initialize()
+        {
+            TerminalManager.CreateUnlockableItemTerminalData(this);
+        }
+
+        internal static ExtendedUnlockableItem Create(UnlockableItem newUnlockableItem, ExtendedMod extendedMod, ContentType contentType)
+        {
+            ExtendedUnlockableItem extendedUnlockableItem = ScriptableObject.CreateInstance<ExtendedUnlockableItem>();
+            extendedUnlockableItem.UnlockableItem = newUnlockableItem;
+            extendedUnlockableItem.name = newUnlockableItem.unlockableName.SkipToLetters().RemoveWhitespace() + "ExtendedUnlockableItem";
+            extendedUnlockableItem.ContentType = contentType;
+            extendedMod.RegisterExtendedContent(extendedUnlockableItem);
+
+            return (extendedUnlockableItem);
+        }
+    }
+}

--- a/LethalLevelLoader/General/Content.cs
+++ b/LethalLevelLoader/General/Content.cs
@@ -20,6 +20,7 @@ namespace LethalLevelLoader
         internal static Dictionary<Item, ExtendedItem> ExtendedItemDictionary = new Dictionary<Item, ExtendedItem>();
         internal static Dictionary<EnemyType, ExtendedEnemyType> ExtendedEnemyTypeDictionary = new Dictionary<EnemyType, ExtendedEnemyType>();
         internal static Dictionary<BuyableVehicle, ExtendedBuyableVehicle> ExtendedBuyableVehicleDictionary = new Dictionary<BuyableVehicle, ExtendedBuyableVehicle>();
+        internal static Dictionary<UnlockableItem, ExtendedUnlockableItem> ExtendedUnlockableItemDictionary = new Dictionary<UnlockableItem, ExtendedUnlockableItem>();
 
 
         public static List<ExtendedLevel> ExtendedLevels { get; internal set; } = new List<ExtendedLevel>();
@@ -208,6 +209,34 @@ namespace LethalLevelLoader
         }
 
 
+
+        public static List<ExtendedUnlockableItem> ExtendedUnlockableItems { get; internal set; } = new List<ExtendedUnlockableItem>();
+
+        public static List<ExtendedUnlockableItem> CustomExtendedUnlockableItems
+        {
+            get
+            {
+                List<ExtendedUnlockableItem> returnList = new List<ExtendedUnlockableItem>();
+                foreach (ExtendedUnlockableItem extendedUnlockableItem in ExtendedUnlockableItems)
+                    if (extendedUnlockableItem.ContentType == ContentType.Custom)
+                        returnList.Add(extendedUnlockableItem);
+                return (returnList);
+            }
+        }
+
+        public static List<ExtendedUnlockableItem> VanillaExtendedUnlockableItems
+        {
+            get
+            {
+                List<ExtendedUnlockableItem> returnList = new List<ExtendedUnlockableItem>();
+                foreach (ExtendedUnlockableItem extendedUnlockableItem in ExtendedUnlockableItems)
+                    if (extendedUnlockableItem.ContentType == ContentType.Vanilla)
+                        returnList.Add(extendedUnlockableItem);
+                return (returnList);
+            }
+        }
+
+
         public static List<AudioMixer> AudioMixers { get; internal set; } = new List<AudioMixer>();
 
         public static List<AudioMixerGroup> AudioMixerGroups { get; internal set; } = new List<AudioMixerGroup>();
@@ -286,6 +315,11 @@ namespace LethalLevelLoader
                 TryAdd(ExtendedBuyableVehicleDictionary, extendedBuyableVehicle.BuyableVehicle, extendedBuyableVehicle);
                 TryAddUUID(extendedBuyableVehicle);
             }
+            foreach (ExtendedUnlockableItem extendedUnlockableItem in ExtendedUnlockableItems)
+            {
+                TryAdd(ExtendedUnlockableItemDictionary, extendedUnlockableItem.UnlockableItem, extendedUnlockableItem);
+                TryAddUUID(extendedUnlockableItem);
+            }
         }
 
         internal static void TryAddUUID(ExtendedContent extendedContent)
@@ -333,6 +367,11 @@ namespace LethalLevelLoader
             return (ExtendedBuyableVehicleDictionary.TryGetValue(buyableVehicle, out extendedBuyableVehicle));
         }
 
+        public static bool TryGetExtendedContent(UnlockableItem unlockableItem, out ExtendedUnlockableItem extendedUnlockableItem)
+        {
+            return (ExtendedUnlockableItemDictionary.TryGetValue(unlockableItem, out extendedUnlockableItem));
+        }
+
         public static bool TryGetExtendedContent<T>(string uniqueIdentifierName, out T extendedContent) where T : ExtendedContent
         {
             extendedContent = null;
@@ -364,6 +403,10 @@ namespace LethalLevelLoader
         public static List<Item> Items { get; internal set; } = new List<Item>();
 
         public static List<ItemGroup> ItemGroups { get; internal set; } = new List<ItemGroup>();
+
+        //Unlockable Items
+
+        public static List<UnlockableItem> UnlockableItems { get; internal set; } = new List<UnlockableItem>();
 
         //Enemies
 

--- a/LethalLevelLoader/General/Patches.cs
+++ b/LethalLevelLoader/General/Patches.cs
@@ -186,6 +186,7 @@ if (AssetBundleLoader.noBundlesFound == true)
 
                 DebugStopwatch.StartStopWatch("Scrape Vanilla Content");
                 ContentExtractor.TryScrapeVanillaItems(StartOfRound);
+                ContentExtractor.TryScrapeVanillaUnlockableItems(StartOfRound);
                 ContentExtractor.TryScrapeVanillaContent(StartOfRound, RoundManager);
                 ContentExtractor.ObtainSpecialItemReferences();
 
@@ -228,6 +229,7 @@ if (AssetBundleLoader.noBundlesFound == true)
                 AssetBundleLoader.CreateVanillaExtendedItems();
                 AssetBundleLoader.CreateVanillaExtendedEnemyTypes();
                 AssetBundleLoader.CreateVanillaExtendedBuyableVehicles();
+                AssetBundleLoader.CreateVanillaExtendedUnlockableItems(StartOfRound);
 
                 DebugStopwatch.StartStopWatch("Initialize Custom ExtendedContent"); // this is not used
                 //Initialize ExtendedContent Objects For Custom Content.
@@ -346,13 +348,23 @@ if (AssetBundleLoader.noBundlesFound == true)
             //Dynamically Inject Custom EnemyType's Into SelectableLevel's Based On Level & Dungeon MatchingProperties.
             EnemyManager.RefreshDynamicEnemyTypeRarityOnAllExtendedLevels();
 
-            DebugStopwatch.StartStopWatch("Create ExtendedLevelGroups & Filter Assets");
+            DebugStopwatch.StartStopWatch("ExtendedBuyableVehicle Injection");
 
             VehiclesManager.PatchVanillaVehiclesLists();
             VehiclesManager.SetBuyableVehicleIDs();
 
             foreach (ExtendedBuyableVehicle customExtendedBuyableVehicle in PatchedContent.CustomExtendedBuyableVehicles)
                 TerminalManager.CreateBuyableVehicleTerminalData(customExtendedBuyableVehicle);
+
+            DebugStopwatch.StartStopWatch("ExtendedUnlockableItem Injection");
+
+            UnlockableItemManager.PatchVanillaUnlockableItemLists();
+            UnlockableItemManager.SetUnlockableItemIDs();
+
+            foreach (ExtendedBuyableVehicle customExtendedBuyableVehicle in PatchedContent.CustomExtendedBuyableVehicles)
+                TerminalManager.CreateBuyableVehicleTerminalData(customExtendedBuyableVehicle);
+
+            DebugStopwatch.StartStopWatch("Create ExtendedLevelGroups & Filter Assets");
 
             //Populate SelectableLevel Data To Be Used In Overhaul Of The Terminal Moons Catalogue.
             TerminalManager.CreateExtendedLevelGroups();
@@ -407,6 +419,18 @@ if (AssetBundleLoader.noBundlesFound == true)
                             allVehicles.Add(extendedBuyableVehicle.BuyableVehicle);
 
                         Terminal.buyableVehicles = [.. allVehicles];
+                    }
+                    // ...
+
+                    // Load ExtendedUnlockableItem store page entries:
+                    if (extendedMod.ExtendedUnlockableItems.Count > 0)
+                    {
+                        List<UnlockableItem> allBuyableUnlockableItems = [.. StartOfRound.unlockablesList.unlockables];
+
+                        foreach (ExtendedUnlockableItem extendedUnlockableItem in extendedMod.ExtendedUnlockableItems)
+                            allBuyableUnlockableItems.Add(extendedUnlockableItem.UnlockableItem);
+
+                        StartOfRound.unlockablesList.unlockables = [.. allBuyableUnlockableItems];
                     }
                     // ...
                 }

--- a/LethalLevelLoader/LethalLevelLoader.csproj
+++ b/LethalLevelLoader/LethalLevelLoader.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 
@@ -63,7 +63,7 @@
 
   <ItemGroup>
     <PackageReference Include="MaxWasUnavailable.LethalModDataLib" Version="1.2.2" />
-    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="67.0.0-ngd.0" Publicize="true" />
+    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="70.0.0-ngd.0" Publicize="true"/>
   </ItemGroup>
 
   <Target Name="NetcodePatch" AfterTargets="PostBuildEvent">

--- a/LethalLevelLoader/Patches/TerminalManager.cs
+++ b/LethalLevelLoader/Patches/TerminalManager.cs
@@ -981,9 +981,6 @@ namespace LethalLevelLoader
             extendedUnlockableItem.BuyInfoNode = terminalNodeInfo;
 
             extendedUnlockableItem.UnlockableItem.shopSelectionNode = extendedUnlockableItem.BuyNode;
-
-            if (!Patches.StartOfRound.unlockablesList.unlockables.Contains(extendedUnlockableItem.UnlockableItem))
-                Patches.StartOfRound.unlockablesList.unlockables.Add(extendedUnlockableItem.UnlockableItem);
         }
 
         internal static void RegisterStoryLog(TerminalKeyword terminalKeyword, TerminalNode terminalNode)

--- a/LethalLevelLoader/Patches/TerminalManager.cs
+++ b/LethalLevelLoader/Patches/TerminalManager.cs
@@ -886,6 +886,106 @@ namespace LethalLevelLoader
             buyKeyword.AddCompatibleNoun(newVehicleTerminalKeyword, newVehicleBuyNode);
         }
 
+        internal static void CreateUnlockableItemTerminalData(ExtendedUnlockableItem extendedUnlockableItem)
+        {
+            int unlockableItemIndex = Patches.StartOfRound.unlockablesList.unlockables.Count();
+
+
+
+            //Terminal Buy Keyword
+            TerminalKeyword terminalKeyword = CreateNewTerminalKeyword();
+            terminalKeyword.name = extendedUnlockableItem.UnlockableItem.unlockableName.StripSpecialCharacters().Sanitized() + "Keyword";
+            terminalKeyword.word = extendedUnlockableItem.UnlockableItem.unlockableName.StripSpecialCharacters().Sanitized();
+            terminalKeyword.defaultVerb = buyKeyword;
+
+            //Terminal Buy Keyword
+            TerminalNode terminalNodeBuy;
+            if (extendedUnlockableItem.BuyNode != null)
+                terminalNodeBuy = extendedUnlockableItem.BuyNode;
+            else
+            {
+                terminalNodeBuy = CreateNewTerminalNode();
+                terminalNodeBuy.name = extendedUnlockableItem.UnlockableItem.unlockableName.StripSpecialCharacters().Sanitized() + "Buy";
+                terminalNodeBuy.itemCost = extendedUnlockableItem.ItemCost;
+                terminalNodeBuy.isConfirmationNode = false;
+                terminalNodeBuy.overrideOptions = true;
+                terminalNodeBuy.clearPreviousText = true;
+                terminalNodeBuy.maxCharactersToType = 15;
+                terminalNodeBuy.creatureName = extendedUnlockableItem.UnlockableItem.unlockableName;
+                if (extendedUnlockableItem.OverrideBuyNodeDescription != string.Empty)
+                    terminalNodeBuy.displayText = extendedUnlockableItem.OverrideBuyNodeDescription;
+                else
+                {
+                    terminalNodeBuy.displayText = $"You have requested to order the {terminalNodeBuy.creatureName}.";
+                    terminalNodeBuy.displayText += "\n Total cost of item: [totalCost].";
+                    terminalNodeBuy.displayText += "\n" + "\n" + "Please CONFIRM or DENY." + "\n" + "\n";
+                }
+            }
+            terminalNodeBuy.shipUnlockableID = unlockableItemIndex;
+
+            //Terminal Buy Confirm Node
+            TerminalNode terminalNodeBuyConfirm;
+            if (extendedUnlockableItem.BuyConfirmNode != null)
+                terminalNodeBuyConfirm = extendedUnlockableItem.BuyConfirmNode;
+            else
+            {
+                terminalNodeBuyConfirm = CreateNewTerminalNode();
+                terminalNodeBuyConfirm.name = extendedUnlockableItem.UnlockableItem.unlockableName.StripSpecialCharacters().Sanitized() + "BuyConfirm";
+                terminalNodeBuyConfirm.itemCost = extendedUnlockableItem.ItemCost;
+                terminalNodeBuyConfirm.isConfirmationNode = false;
+                terminalNodeBuyConfirm.clearPreviousText = true;
+                terminalNodeBuyConfirm.buyUnlockable = true;
+                terminalNodeBuyConfirm.maxCharactersToType = 35;
+                terminalNodeBuyConfirm.playSyncedClip = 0;
+                terminalNodeBuyConfirm.creatureName = extendedUnlockableItem.UnlockableItem.unlockableName;
+                if (extendedUnlockableItem.OverrideBuyConfirmNodeDescription != string.Empty)
+                    terminalNodeBuyConfirm.displayText = extendedUnlockableItem.OverrideBuyConfirmNodeDescription;
+                else
+                {
+                    terminalNodeBuyConfirm.displayText = $"Ordered the {terminalNodeBuyConfirm.creatureName}! ";
+                    terminalNodeBuyConfirm.displayText += "Your new balance is [playerCredits]";
+                }
+            }
+            terminalNodeBuyConfirm.shipUnlockableID = unlockableItemIndex;
+
+            //Terminal Info Node
+            TerminalNode terminalNodeInfo = null;
+            if (!string.IsNullOrEmpty(extendedUnlockableItem.OverrideInfoNodeDescription))
+            {
+                if (extendedUnlockableItem.BuyInfoNode != null)
+                    terminalNodeInfo = extendedUnlockableItem.BuyInfoNode;
+                else
+                {
+                    terminalNodeInfo = CreateNewTerminalNode();
+                    terminalNodeInfo.name = extendedUnlockableItem.UnlockableItem.unlockableName.StripSpecialCharacters().Sanitized() + "Info";
+                    terminalNodeInfo.clearPreviousText = true;
+                    terminalNodeInfo.maxCharactersToType = 25;
+                    terminalNodeInfo.displayText = "\n" + extendedUnlockableItem.OverrideInfoNodeDescription;
+                    terminalNodeInfo.creatureName = extendedUnlockableItem.UnlockableItem.unlockableName;
+                }
+            }
+
+
+            //Population Into Base game
+
+            terminalNodeBuy.AddCompatibleNoun(routeConfirmKeyword, terminalNodeBuyConfirm);
+            terminalNodeBuy.AddCompatibleNoun(routeDenyKeyword, cancelPurchaseNode);
+
+            buyKeyword.AddCompatibleNoun(terminalKeyword, terminalNodeBuy);
+
+            if (terminalNodeInfo != null)
+                routeInfoKeyword.AddCompatibleNoun(terminalKeyword, terminalNodeInfo);
+
+            extendedUnlockableItem.BuyNode = terminalNodeBuy;
+            extendedUnlockableItem.BuyConfirmNode = terminalNodeBuyConfirm;
+            extendedUnlockableItem.BuyInfoNode = terminalNodeInfo;
+
+            extendedUnlockableItem.UnlockableItem.shopSelectionNode = extendedUnlockableItem.BuyNode;
+
+            if (!Patches.StartOfRound.unlockablesList.unlockables.Contains(extendedUnlockableItem.UnlockableItem))
+                Patches.StartOfRound.unlockablesList.unlockables.Add(extendedUnlockableItem.UnlockableItem);
+        }
+
         internal static void RegisterStoryLog(TerminalKeyword terminalKeyword, TerminalNode terminalNode)
         {
 

--- a/LethalLevelLoader/Patches/UnlockableItemManager.cs
+++ b/LethalLevelLoader/Patches/UnlockableItemManager.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+
+namespace LethalLevelLoader
+{
+    public static class UnlockableItemManager
+    {
+        internal static void PatchVanillaUnlockableItemLists()
+        {
+            Patches.StartOfRound.unlockablesList.unlockables = [.. PatchedContent.ExtendedUnlockableItems.Select(u => u.UnlockableItem)];
+        }
+
+        internal static void SetUnlockableItemIDs()
+        {
+            int unlockableID = 0;
+            foreach (ExtendedUnlockableItem vanillaUnlockableItem in PatchedContent.VanillaExtendedUnlockableItems)
+                vanillaUnlockableItem.UnlockableItemID = unlockableID++;
+
+            foreach (ExtendedUnlockableItem customUnlockableItem in PatchedContent.CustomExtendedUnlockableItems)
+                customUnlockableItem.UnlockableItemID = unlockableID++;
+
+            foreach (ExtendedUnlockableItem extendedUnlockableItem in PatchedContent.ExtendedUnlockableItems)
+            {
+                if (extendedUnlockableItem.UnlockableItem.unlockableType == 1)
+                {
+                    if (extendedUnlockableItem.UnlockableItem.prefabObject == null && extendedUnlockableItem.UnlockableItem.alreadyUnlocked)
+                    {
+                        continue;
+                    }
+
+                    AutoParentToShip autoParentToShip = extendedUnlockableItem.UnlockableItem.prefabObject.GetComponent<AutoParentToShip>();
+                    autoParentToShip.unlockableID = extendedUnlockableItem.UnlockableItemID;
+
+                    PlaceableShipObject placeableShipObject = extendedUnlockableItem.UnlockableItem.prefabObject.GetComponentInChildren<PlaceableShipObject>();
+                    if (placeableShipObject != null)
+                    {
+                        placeableShipObject.parentObject = autoParentToShip;
+                        placeableShipObject.unlockableID = extendedUnlockableItem.UnlockableItemID;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/LethalLevelLoader/Tools/AssetBundleLoader.cs
+++ b/LethalLevelLoader/Tools/AssetBundleLoader.cs
@@ -94,6 +94,10 @@ namespace LethalLevelLoader
                     LethalLevelLoaderNetworkManager.RegisterNetworkPrefab(extendedBuyableVehicle.BuyableVehicle.vehiclePrefab);
                     LethalLevelLoaderNetworkManager.RegisterNetworkPrefab(extendedBuyableVehicle.BuyableVehicle.secondaryPrefab);
                 }
+
+                foreach (ExtendedUnlockableItem extendedUnlockableItem in extendedMod.ExtendedUnlockableItems)
+                    if (extendedUnlockableItem.UnlockableItem.unlockableType == 1 && extendedUnlockableItem.UnlockableItem.prefabObject != null)
+                        LethalLevelLoaderNetworkManager.RegisterNetworkPrefab(extendedUnlockableItem.UnlockableItem.prefabObject);
             }
         }
 
@@ -505,6 +509,12 @@ namespace LethalLevelLoader
                     extendedBuyableVehicle.ContentType = ContentType.Custom;
                     PatchedContent.ExtendedBuyableVehicles.Add(extendedBuyableVehicle);
                 }    
+                foreach (ExtendedUnlockableItem extendedUnlockableItem in extendedMod.ExtendedUnlockableItems)
+                {
+                    extendedUnlockableItem.ContentType = ContentType.Custom;
+                    extendedUnlockableItem.Initialize();
+                    PatchedContent.ExtendedUnlockableItems.Add(extendedUnlockableItem);
+                }    
             }
             //DebugHelper.DebugAllLevels();
         }
@@ -668,6 +678,19 @@ namespace LethalLevelLoader
             ExtendedBuyableVehicle newExtendedVanillaBuyableVehicle = ExtendedBuyableVehicle.Create(buyableVehicle);
             PatchedContent.VanillaMod.RegisterExtendedContent(newExtendedVanillaBuyableVehicle);
             PatchedContent.ExtendedBuyableVehicles.Add(newExtendedVanillaBuyableVehicle);
+        }
+
+        internal static void CreateVanillaExtendedUnlockableItems(StartOfRound startOfRound)
+        {
+            foreach (UnlockableItem vanillaUnlockableItem in OriginalContent.UnlockableItems)
+                CreateVanillaExtendedUnlockableItem(vanillaUnlockableItem);
+        }
+
+        internal static void CreateVanillaExtendedUnlockableItem(UnlockableItem unlockableItem)
+        {
+            ExtendedUnlockableItem newExtendedVanillaUnlockableItem = ExtendedUnlockableItem.Create(unlockableItem, PatchedContent.VanillaMod, ContentType.Vanilla);
+            PatchedContent.VanillaMod.RegisterExtendedContent(newExtendedVanillaUnlockableItem);
+            PatchedContent.ExtendedUnlockableItems.Add(newExtendedVanillaUnlockableItem);
         }
 
         internal static void NetworkRegisterDungeonContent(ExtendedDungeonFlow extendedDungeonFlow, NetworkManager networkManager)

--- a/LethalLevelLoader/Tools/ContentExtractor.cs
+++ b/LethalLevelLoader/Tools/ContentExtractor.cs
@@ -33,6 +33,13 @@ namespace LethalLevelLoader
             OriginalContent.ItemGroups = OriginalContent.ItemGroups.Distinct().ToList();
 
         }
+        internal static void TryScrapeVanillaUnlockableItems(StartOfRound startOfRound)
+        {
+            foreach (UnlockableItem item in startOfRound.unlockablesList.unlockables)
+                if (!OriginalContent.UnlockableItems.Contains(item))
+                    OriginalContent.UnlockableItems.Add(item);
+
+        }
         internal static void TryScrapeVanillaContent(StartOfRound startOfRound, RoundManager roundManager)
         {
             if (Plugin.IsSetupComplete == false)

--- a/LethalLevelLoader/Tools/Validators.cs
+++ b/LethalLevelLoader/Tools/Validators.cs
@@ -26,6 +26,8 @@ namespace LethalLevelLoader
                 result = ValidateExtendedContent(extendedStoryLog);
             else if (extendedContent is ExtendedBuyableVehicle extendedBuyableVehicle)
                 result = ValidateExtendedContent(extendedBuyableVehicle);
+            else if (extendedContent is ExtendedUnlockableItem extendedUnlockableItem)
+                result = ValidateExtendedContent(extendedUnlockableItem);
 
             if (result.Item1 == false)
                 DebugHelper.Log(result.Item2, DebugType.Developer);
@@ -136,6 +138,23 @@ namespace LethalLevelLoader
                 return (false, "Vehicle Prefab Is Missing NetworkObject Component");
             else if (extendedBuyableVehicle.BuyableVehicle.secondaryPrefab.GetComponent<NetworkObject>() == null)
                 return (false, "Vehicle Secondary Prefab Is Missing NetworkObject Component");
+
+            return (true, string.Empty);
+        }
+
+        public static (bool result, string log) ValidateExtendedContent(ExtendedUnlockableItem extendedUnlockableItem)
+        {
+            if (extendedUnlockableItem.UnlockableItem.unlockableType == 1 && !extendedUnlockableItem.UnlockableItem.alreadyUnlocked)
+            {
+                if (extendedUnlockableItem.UnlockableItem.prefabObject == null)
+                    return (false, "Unlockable Item Prefab Was Null Or Empty");
+                else if (!extendedUnlockableItem.UnlockableItem.prefabObject.TryGetComponent(out NetworkObject _))
+                    return (false, "Unlockable Item Prefab Is Missing NetworkObject Component");
+                else if (!extendedUnlockableItem.UnlockableItem.prefabObject.TryGetComponent(out AutoParentToShip _))
+                    return (false, "Unlockable Item Prefab Is Missing AutoParentToShip Component");
+            }
+            else if (extendedUnlockableItem.UnlockableItem.unlockableType == 0 && extendedUnlockableItem.UnlockableItem.suitMaterial == null)
+                return (false, "Unlockable Suit Is Missing Suit Material");
 
             return (true, string.Empty);
         }


### PR DESCRIPTION
- Updated game assemblies to `v70` in the `.csproj` file
- Implemented `ExtendedUnlockableItem`, for ship unlockables (suits, ship furniture, ship upgrades)
  - Did some testing to confirm it's all working alright, and it appears to be
- Fixed `OnLethalBundleLoaded` listeners being called multiple times (once for every bundle found)

_Might_ not be quite enough to warrant a `v1.5.0` LLL release, so I just left it at `v1.4.12` .