### PR TITLE
Updated for v73, also a couple fixes.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
         ]
       },
       "evaisa.netcodepatcher.cli": {
-        "version": "3.3.3",
+        "version": "4.4.2",
         "commands": [
           "netcode-patch"
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,24 @@
 **Changelog**
 --
 
-**<details><summary>Version 1.4.12</summary>**
+**<details><summary>Version 1.5.0</summary>**
 
 **<details><summary>Features</summary>**
 
-* Updated mod for Lethal Company version 70
+* Updated mod for Lethal Company version 73
 * Added ExtendedUnlockableItem (suits, ship furniture, ship upgrades)
+
+</details>
 
 **<details><summary>Fixes</summary>**
 
 * Fixed SpawnableMapObjects defined in ExtendedDungeonFlow not spawning for clients
 * Fixed some ExtendedContent not being re-registered on the terminal after a lobby reload
 * Fixed OnLethalBundleLoaded listeners being called multiple times (once for every bundle found)
+* Fixed bundle of the currently-routed moon unloading immediately after reloading the save file
+  * Should make [LLLHotreloadPatch](https://thunderstore.io/c/lethal-company/p/dopadream/LLLHotreloadPatch) no longer needed
+
+</details>
 
 </details>
 

--- a/LethalLevelLoader/General/Patches.cs
+++ b/LethalLevelLoader/General/Patches.cs
@@ -356,13 +356,16 @@ if (AssetBundleLoader.noBundlesFound == true)
             foreach (ExtendedBuyableVehicle customExtendedBuyableVehicle in PatchedContent.CustomExtendedBuyableVehicles)
                 TerminalManager.CreateBuyableVehicleTerminalData(customExtendedBuyableVehicle);
 
-            DebugStopwatch.StartStopWatch("ExtendedUnlockableItem Injection");
+            if (Plugin.IsSetupComplete == false) // Only needs to be done once.
+            {
+                DebugStopwatch.StartStopWatch("ExtendedUnlockableItem Injection");
 
-            UnlockableItemManager.PatchVanillaUnlockableItemLists();
-            UnlockableItemManager.SetUnlockableItemIDs();
+                UnlockableItemManager.PatchVanillaUnlockableItemLists();
+                UnlockableItemManager.SetUnlockableItemIDs();
 
-            foreach (ExtendedBuyableVehicle customExtendedBuyableVehicle in PatchedContent.CustomExtendedBuyableVehicles)
-                TerminalManager.CreateBuyableVehicleTerminalData(customExtendedBuyableVehicle);
+                foreach (ExtendedUnlockableItem customExtendedUnlockableItem in PatchedContent.CustomExtendedUnlockableItems)
+                    TerminalManager.CreateUnlockableItemTerminalData(customExtendedUnlockableItem);
+            }
 
             DebugStopwatch.StartStopWatch("Create ExtendedLevelGroups & Filter Assets");
 
@@ -419,18 +422,6 @@ if (AssetBundleLoader.noBundlesFound == true)
                             allVehicles.Add(extendedBuyableVehicle.BuyableVehicle);
 
                         Terminal.buyableVehicles = [.. allVehicles];
-                    }
-                    // ...
-
-                    // Load ExtendedUnlockableItem store page entries:
-                    if (extendedMod.ExtendedUnlockableItems.Count > 0)
-                    {
-                        List<UnlockableItem> allBuyableUnlockableItems = [.. StartOfRound.unlockablesList.unlockables];
-
-                        foreach (ExtendedUnlockableItem extendedUnlockableItem in extendedMod.ExtendedUnlockableItems)
-                            allBuyableUnlockableItems.Add(extendedUnlockableItem.UnlockableItem);
-
-                        StartOfRound.unlockablesList.unlockables = [.. allBuyableUnlockableItems];
                     }
                     // ...
                 }

--- a/LethalLevelLoader/LethalLevelLoader.csproj
+++ b/LethalLevelLoader/LethalLevelLoader.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Evaisa.LethalLib" Version="0.16.2" />
+    <PackageReference Include="Evaisa.LethalLib" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="MinVer" Version="4.*" PrivateAssets="all" Private="false" />
   </ItemGroup>
 
@@ -58,16 +58,16 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="BepInEx.Core" Version="5.4.21" />
+    <PackageReference Include="BepInEx.Core" Version="5.4.21" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaxWasUnavailable.LethalModDataLib" Version="1.2.2" />
-    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="70.0.0-ngd.0" Publicize="true"/>
+    <PackageReference Include="MaxWasUnavailable.LethalModDataLib" Version="1.2.2" PrivateAssets="all" />
+    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="73.0.0-ngd.0" PrivateAssets="all" Publicize="true" />
   </ItemGroup>
 
   <Target Name="NetcodePatch" AfterTargets="PostBuildEvent">
-    <Exec Command="netcode-patch &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies-> '&quot;%(Identity)&quot;', ' ')" />
+    <Exec Command="netcode-patch -uv 2022.3.62 -nv 1.12.0 -tv 1.0.0 &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies->'&quot;%(Identity)&quot;', ' ')" />
   </Target>
 
   <PropertyGroup>

--- a/LethalLevelLoader/LethalLevelLoader.csproj
+++ b/LethalLevelLoader/LethalLevelLoader.csproj
@@ -5,7 +5,7 @@
       <TargetFramework>netstandard2.1</TargetFramework>
       <AssemblyName>LethalLevelLoader</AssemblyName>
       <Description>A Custom API to support the manual and dynamic integration of custom levels and dungeons in Lethal Company.</Description>
-      <Version>1.4.12</Version>
+      <Version>1.5.0</Version>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
       <LangVersion>preview</LangVersion>
 

--- a/LethalLevelLoader/Patches/LethalLevelLoaderNetworkManager.cs
+++ b/LethalLevelLoader/Patches/LethalLevelLoaderNetworkManager.cs
@@ -35,8 +35,15 @@ namespace LethalLevelLoader
         public override void OnNetworkSpawn()
         {
             base.OnNetworkSpawn();
-            gameObject.name = "LethalLevelLoaderNetworkManager";
+
+            if (_instance != null && _instance != this) // Using '_instance' to avoid the FindObjectOfType() search + error log.
+            {
+                Destroy(Instance);
+            }
+
             Instance = this;
+
+            gameObject.name = "LethalLevelLoaderNetworkManager";
             DebugHelper.Log("LethalLevelLoaderNetworkManager Spawned.", DebugType.User);
         }
 

--- a/LethalLevelLoader/Patches/LethalLevelLoaderNetworkManager.cs
+++ b/LethalLevelLoader/Patches/LethalLevelLoaderNetworkManager.cs
@@ -47,7 +47,7 @@ namespace LethalLevelLoader
             DebugHelper.Log("LethalLevelLoaderNetworkManager Spawned.", DebugType.User);
         }
 
-        [Rpc(SendTo.Server)]
+        [ServerRpc]
         public void GetRandomExtendedDungeonFlowServerRpc()
         {
             DebugHelper.Log("Getting Random DungeonFlows!", DebugType.User);
@@ -83,7 +83,7 @@ namespace LethalLevelLoader
             SetRandomExtendedDungeonFlowClientRpc(dungeonFlowNames.ToArray(), rarities.ToArray());
         }
 
-        [Rpc(SendTo.Server)]
+        [ServerRpc]
         public void GetUpdatedLevelCurrentWeatherServerRpc()
         {
             List<StringContainer> levelNames = new List<StringContainer>();
@@ -99,7 +99,7 @@ namespace LethalLevelLoader
             SetUpdatedLevelCurrentWeatherClientRpc(levelNames.ToArray(), weatherTypes.ToArray());
         }
 
-        [Rpc(SendTo.ClientsAndHost)]
+        [ClientRpc]
         public void SetUpdatedLevelCurrentWeatherClientRpc(StringContainer[] levelNames, LevelWeatherType[] weatherTypes)
         {
             Dictionary<ExtendedLevel, LevelWeatherType> syncedLevelCurrentWeathers = new Dictionary<ExtendedLevel, LevelWeatherType>();
@@ -119,7 +119,7 @@ namespace LethalLevelLoader
             }
         }
 
-        [Rpc(SendTo.ClientsAndHost)]
+        [ClientRpc]
         public void SetRandomExtendedDungeonFlowClientRpc(StringContainer[] dungeonFlowNames, int[] rarities)
         {
             DebugHelper.Log("Setting Random DungeonFlows!", DebugType.User);
@@ -145,20 +145,20 @@ namespace LethalLevelLoader
             LevelManager.CurrentExtendedLevel.SelectableLevel.dungeonFlowTypes = cachedDungeonFlowsList.ToArray();
         }
 
-        [Rpc(SendTo.Server)]
+        [ServerRpc]
         public void GetDungeonFlowSizeServerRpc()
         {
             SetDungeonFlowSizeClientRpc(DungeonLoader.GetClampedDungeonSize());
         }
 
-        [Rpc(SendTo.ClientsAndHost)]
+        [ClientRpc]
         public void SetDungeonFlowSizeClientRpc(float hostSize)
         {
             Patches.RoundManager.dungeonGenerator.Generator.LengthMultiplier = hostSize;
             Patches.RoundManager.dungeonGenerator.Generate();
         }
 
-        [Rpc(SendTo.Server)]
+        [ServerRpc]
         internal void SetExtendedLevelValuesServerRpc(ExtendedLevelData extendedLevelData)
         {
             if (PatchedContent.TryGetExtendedContent(extendedLevelData.UniqueIdentifier, out ExtendedLevel extendedLevel))
@@ -166,7 +166,7 @@ namespace LethalLevelLoader
             else
                 DebugHelper.Log("Failed To Send Level Info!", DebugType.User);
         }
-        [Rpc(SendTo.ClientsAndHost)]
+        [ClientRpc]
         internal void SetExtendedLevelValuesClientRpc(ExtendedLevelData extendedLevelData)
         {
             if (PatchedContent.TryGetExtendedContent(extendedLevelData.UniqueIdentifier, out ExtendedLevel extendedLevel))

--- a/LethalLevelLoader/Patches/LethalLevelLoaderNetworkManager.cs
+++ b/LethalLevelLoader/Patches/LethalLevelLoaderNetworkManager.cs
@@ -40,7 +40,7 @@ namespace LethalLevelLoader
             DebugHelper.Log("LethalLevelLoaderNetworkManager Spawned.", DebugType.User);
         }
 
-        [ServerRpc]
+        [Rpc(SendTo.Server)]
         public void GetRandomExtendedDungeonFlowServerRpc()
         {
             DebugHelper.Log("Getting Random DungeonFlows!", DebugType.User);
@@ -76,7 +76,7 @@ namespace LethalLevelLoader
             SetRandomExtendedDungeonFlowClientRpc(dungeonFlowNames.ToArray(), rarities.ToArray());
         }
 
-        [ServerRpc]
+        [Rpc(SendTo.Server)]
         public void GetUpdatedLevelCurrentWeatherServerRpc()
         {
             List<StringContainer> levelNames = new List<StringContainer>();
@@ -92,7 +92,7 @@ namespace LethalLevelLoader
             SetUpdatedLevelCurrentWeatherClientRpc(levelNames.ToArray(), weatherTypes.ToArray());
         }
 
-        [ClientRpc]
+        [Rpc(SendTo.ClientsAndHost)]
         public void SetUpdatedLevelCurrentWeatherClientRpc(StringContainer[] levelNames, LevelWeatherType[] weatherTypes)
         {
             Dictionary<ExtendedLevel, LevelWeatherType> syncedLevelCurrentWeathers = new Dictionary<ExtendedLevel, LevelWeatherType>();
@@ -112,7 +112,7 @@ namespace LethalLevelLoader
             }
         }
 
-        [ClientRpc]
+        [Rpc(SendTo.ClientsAndHost)]
         public void SetRandomExtendedDungeonFlowClientRpc(StringContainer[] dungeonFlowNames, int[] rarities)
         {
             DebugHelper.Log("Setting Random DungeonFlows!", DebugType.User);
@@ -138,20 +138,20 @@ namespace LethalLevelLoader
             LevelManager.CurrentExtendedLevel.SelectableLevel.dungeonFlowTypes = cachedDungeonFlowsList.ToArray();
         }
 
-        [ServerRpc]
+        [Rpc(SendTo.Server)]
         public void GetDungeonFlowSizeServerRpc()
         {
             SetDungeonFlowSizeClientRpc(DungeonLoader.GetClampedDungeonSize());
         }
 
-        [ClientRpc]
+        [Rpc(SendTo.ClientsAndHost)]
         public void SetDungeonFlowSizeClientRpc(float hostSize)
         {
             Patches.RoundManager.dungeonGenerator.Generator.LengthMultiplier = hostSize;
             Patches.RoundManager.dungeonGenerator.Generate();
         }
 
-        [ServerRpc]
+        [Rpc(SendTo.Server)]
         internal void SetExtendedLevelValuesServerRpc(ExtendedLevelData extendedLevelData)
         {
             if (PatchedContent.TryGetExtendedContent(extendedLevelData.UniqueIdentifier, out ExtendedLevel extendedLevel))
@@ -159,7 +159,7 @@ namespace LethalLevelLoader
             else
                 DebugHelper.Log("Failed To Send Level Info!", DebugType.User);
         }
-        [ClientRpc]
+        [Rpc(SendTo.ClientsAndHost)]
         internal void SetExtendedLevelValuesClientRpc(ExtendedLevelData extendedLevelData)
         {
             if (PatchedContent.TryGetExtendedContent(extendedLevelData.UniqueIdentifier, out ExtendedLevel extendedLevel))

--- a/LethalLevelLoader/Patches/NetworkBundleManager.cs
+++ b/LethalLevelLoader/Patches/NetworkBundleManager.cs
@@ -121,7 +121,7 @@ namespace LethalLevelLoader
             RequestLoadStatusRefreshServerRpc();
         }
 
-        [Rpc(SendTo.Server, RequireOwnership = false)]
+        [ServerRpc(RequireOwnership = false)]
         internal void RequestLoadStatusRefreshServerRpc()
         {
             DebugHelper.Log("Refeshing Loaded Bundles Status!", DebugType.User);
@@ -131,7 +131,7 @@ namespace LethalLevelLoader
             RequestLoadStatusRefreshClientRpc();
         }
 
-        [Rpc(SendTo.ClientsAndHost)]
+        [ClientRpc]
         private void RequestLoadStatusRefreshClientRpc()
         {
             RefreshLoadStatus();
@@ -154,7 +154,7 @@ namespace LethalLevelLoader
             SetLoadedStatusServerRpc(NetworkManager.LocalClientId, loadedStatus);
         }
 
-        [Rpc(SendTo.Server, RequireOwnership = false)]
+        [ServerRpc(RequireOwnership = false)]
         private void SetLoadedStatusServerRpc(ulong clientID, bool status)
         {
             int index = NetworkManager.ConnectedClientsIds.ToList().IndexOf(clientID);

--- a/LethalLevelLoader/Patches/NetworkBundleManager.cs
+++ b/LethalLevelLoader/Patches/NetworkBundleManager.cs
@@ -30,7 +30,7 @@ namespace LethalLevelLoader
 
         public List<NetworkSceneInfo> networkSceneInfos;
         internal Dictionary<string, List<AssetBundleGroup>> assetBundleGroupSceneDict = new Dictionary<string, List<AssetBundleGroup>>();
-        
+
         //internal List<AssetBundleGroup> currentRouteRequestedBundles = new List<AssetBundleGroup>();
         internal ExtendedLevel currentRouteRequestor;
 
@@ -107,7 +107,7 @@ namespace LethalLevelLoader
             RequestLoadStatusRefreshServerRpc();
         }
 
-        [ServerRpc(RequireOwnership = false)]
+        [Rpc(SendTo.Server, RequireOwnership = false)]
         internal void RequestLoadStatusRefreshServerRpc()
         {
             DebugHelper.Log("Refeshing Loaded Bundles Status!", DebugType.User);
@@ -117,7 +117,7 @@ namespace LethalLevelLoader
             RequestLoadStatusRefreshClientRpc();
         }
 
-        [ClientRpc]
+        [Rpc(SendTo.ClientsAndHost)]
         private void RequestLoadStatusRefreshClientRpc()
         {
             RefreshLoadStatus();
@@ -140,7 +140,7 @@ namespace LethalLevelLoader
             SetLoadedStatusServerRpc(NetworkManager.LocalClientId, loadedStatus);
         }
 
-        [ServerRpc(RequireOwnership = false)]
+        [Rpc(SendTo.Server, RequireOwnership = false)]
         private void SetLoadedStatusServerRpc(ulong clientID, bool status)
         {
             int index = NetworkManager.ConnectedClientsIds.ToList().IndexOf(clientID);

--- a/LethalLevelLoader/Patches/UnlockableItemManager.cs
+++ b/LethalLevelLoader/Patches/UnlockableItemManager.cs
@@ -22,7 +22,7 @@ namespace LethalLevelLoader
             {
                 if (extendedUnlockableItem.UnlockableItem.unlockableType == 1)
                 {
-                    if (extendedUnlockableItem.UnlockableItem.prefabObject == null && extendedUnlockableItem.UnlockableItem.alreadyUnlocked)
+                    if (extendedUnlockableItem.UnlockableItem.prefabObject == null || extendedUnlockableItem.UnlockableItem.alreadyUnlocked)
                     {
                         continue;
                     }

--- a/LethalLevelLoader/Plugin.cs
+++ b/LethalLevelLoader/Plugin.cs
@@ -17,7 +17,7 @@ namespace LethalLevelLoader
     {
         public const string ModGUID = "imabatby.lethallevelloader";
         public const string ModName = "LethalLevelLoader";
-        public const string ModVersion = "1.4.12";
+        public const string ModVersion = "1.5.0";
 
         internal static Plugin Instance;
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 **Description**
 --
 
-### **1.4.12 for Lethal Company v69 Has Released!**
+### **1.5.0 for Lethal Company v73 Has Released!**
 
 **LethalLevelLoader** is a custom API to support the manual and dynamic integration of custom levels and dungeons in Lethal Company.  
 Mod Developers can provide LethalLevelLoader with their custom content via code or via automatic AssetBundle detection, and from there LethalLevelLoader will seamlessly load the content into the game.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "name": "LethalLevelLoader",
     "version_number": "1.5.0",
     "website_url": "https://github.com/IAmBatby/LethalLevelLoader",
-    "description": "A Custom API to support the manual and dynamic integration of all forms of custom content in Lethal Company. (v69 Compatible)",
+    "description": "A Custom API to support the manual and dynamic integration of all forms of custom content in Lethal Company. (v73 Compatible)",
     "dependencies": [
         "MaxWasUnavailable-LethalModDataLib-1.2.2",
         "Evaisa-FixPluginTypesSerialization-1.1.1",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "LethalLevelLoader",
-    "version_number": "1.4.12",
+    "version_number": "1.5.0",
     "website_url": "https://github.com/IAmBatby/LethalLevelLoader",
     "description": "A Custom API to support the manual and dynamic integration of all forms of custom content in Lethal Company. (v69 Compatible)",
     "dependencies": [


### PR DESCRIPTION
## Features
* Updated mod for Lethal Company version 73.

## Fixes
* Fixed bundle of the currently-routed moon unloading immediately after reloading the save file.
  * Should make [LLLHotreloadPatch](https://thunderstore.io/c/lethal-company/p/dopadream/LLLHotreloadPatch) no longer needed.

---

Should probably be moved to its own branch since it can't be automatically merged, and the changes are minor.

(Also in one of the commits I mention Netcode being backwards-compatible with v72, this is in fact **NOT** the case and I was _deceived_ by misinformation!)